### PR TITLE
Add make target to automatically bump chart versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/**/*/.idea
+**/*/.idea
+.idea
 /**/*/.vscode
 *.log

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs tests readme helm-docs
+.PHONY: docs bump-docs tests readme helm-docs bump bump-patch bump-minor bump-major
 
 MASTER_BRANCH=true
 SOURCE_README=README.gotmpl
@@ -6,11 +6,24 @@ TARGET_README=README.md
 
 docs: helm-docs readme
 
+bump-docs: bump helm-docs readme
+
 helm-docs:
-		docker run --rm -v $$(pwd):/src -w /src -u $$(id -u) docker.io/jnorwood/helm-docs:v0.12.0
+	docker run --rm -v $$(pwd):/src -w /src -u $$(id -u) docker.io/jnorwood/helm-docs:v0.12.0
 
 readme:
-		go run readme.go $(SOURCE_README) $(TARGET_README) $(MASTER_BRANCH)
+	go run readme.go $(SOURCE_README) $(TARGET_README) $(MASTER_BRANCH)
+
+bump: bump-patch
+
+bump-major:
+	git diff --exit-code --name-only | while read file; do dirname $$file; done | uniq | xargs -L 1 go run bump.go major
+
+bump-minor:
+	git diff --exit-code --name-only | while read file; do dirname $$file; done | uniq | xargs -L 1 go run bump.go minor
+
+bump-patch:
+	git diff --exit-code --name-only | while read file; do dirname $$file; done | uniq | xargs -L 1 go run bump.go patch
 
 tests:
-		find . -type f -name go.mod | cut -s -f 2,3 -d / - | xargs -I % sh -c "cd % && go test ./..."
+	find . -type f -name go.mod | cut -s -f 2,3 -d / - | xargs -I % sh -c "cd % && go test ./..."

--- a/bump.go
+++ b/bump.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	level := os.Args[1]
+	chart := os.Args[2]
+	chartFile := chart + "/Chart.yaml"
+	if !fileExists(chartFile) {
+		fmt.Fprintf(os.Stdout, "File %s does not exist, skipping\n", chartFile)
+		return
+	}
+	file, err := os.Open(chartFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	r := regexp.MustCompile("version: \"?(?P<major>\\d)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)\"?")
+
+	// Read file
+	scanner := bufio.NewScanner(file)
+	var lines []string
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "version") {
+			// We have found version number
+			match := r.FindStringSubmatch(line)
+			paramsMap := make(map[string]int)
+			for i, name := range r.SubexpNames() {
+				if i > 0 && i <= len(match) {
+					digit, _ := strconv.Atoi(match[i])
+					paramsMap[name] = digit
+				}
+			}
+			// Lets increase it
+			paramsMap[level] = paramsMap[level] + 1
+			newVersion := fmt.Sprintf("version: %d.%d.%d", paramsMap["major"], paramsMap["minor"], paramsMap["patch"])
+			fmt.Fprintf(os.Stdout, "Increasing %s to %s\n", chart, newVersion)
+			lines = append(lines, newVersion)
+		} else {
+			lines = append(lines, line)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Fatal(err)
+	}
+
+	file.Close()
+	// Overwrite the Chart.yaml file
+	file, err = os.Create(chartFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+
+	for _, v := range lines {
+		_, err := fmt.Fprintln(file, v)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+// fileExists checks if a file exists and is not a directory before we
+// try using it to prevent further errors.
+func fileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "postUpgradeTasks": {
+    "commands": ["make bump-docs"],
+    "fileFilters": ["**/Chart.yaml", "**/README.md"]
+  }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to ccremer/charts. Before you submit this PR I'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Please make sure that you let https://github.com/norwoodj/helm-docs generate the
documentation. You can do that by running

    make docs

This will create README.md files based on the values.yaml file.
-->

#### What this PR does / why we need it:

* Add make target that can bump chart versions
* Configure Renovate so that it executes make target. Don't know if that actually works on GH:
https://docs.renovatebot.com/configuration-options/#postupgradetasks

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [ ] Chart Version bumped
- [ ] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata). Run `make docs` to generate the README.md.
- [ ] Title of the PR contains starts with chart name e.g. `[chart]`
