### PR TITLE
[znapzend] Initialize znapzend with Backup plans

### DIFF
--- a/znapzend/Chart.yaml
+++ b/znapzend/Chart.yaml
@@ -14,7 +14,7 @@ description: Znapzend Helm Chart for automated ZFS snapshot & replication
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.4.2
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/znapzend/README.md
+++ b/znapzend/README.md
@@ -2,7 +2,7 @@ znapzend
 ========
 Znapzend Helm Chart for automated ZFS snapshot & replication
 
-Current chart version is `0.4.2`
+Current chart version is `0.5.0`
 
 
 
@@ -13,24 +13,25 @@ Current chart version is `0.4.2`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| env | object | `{}` | A dict with KEY: VALUE pairs |
+| env | object | `{}` | A dict with `KEY: VALUE` pairs |
 | fullnameOverride | string | `""` |  |
-| host.zfsDevice | string | `"/dev/zfs"` | The device on the host which is used by the 'zfs' binary within the container |
+| host.zfsDevice | string | `"/dev/zfs"` | The device on the host which is used by the `zfs` binary within the container |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"docker.io"` | Znapzend image registry |
 | image.repository | string | `"oetiker/znapzend"` | Znapzend image repository |
 | image.tag | string | `"v0.20.0"` | Znapzend image tag (version) |
 | imagePullSecrets | list | `[]` | List of image pull secrets if you use a privately hosted image |
-| metrics.enabled | bool | `true` | Enable the znapzend metrics exporter for Prometheus |
-| metrics.env | object | `{}` | A dict with KEY: VALUE pairs as environment variables for the exporter |
+| metrics.enabled | bool | `true` | Enable the metrics exporter for Prometheus |
+| metrics.env | object | `{}` | A dict with `KEY: VALUE` pairs as environment variables for the exporter |
 | metrics.image.pullPolicy | string | `"IfNotPresent"` |  |
 | metrics.image.repository | string | `"docker.io/ccremer/znapzend-exporter"` | Exporter image repository |
 | metrics.image.tag | string | `"v0.2.2"` | Exporter image tag |
 | metrics.ingress.annotations | object | `{}` |  |
 | metrics.ingress.enabled | bool | `false` | Useful if your Prometheus is outside of the cluster |
-| metrics.ingress.hosts | list | `[{"host":null,"paths":[]}]` | See Kubernetes Docs for a guide to setup TLS on Ingress |
+| metrics.ingress.hosts | list | `[]` | See Kubernetes Docs for a guide to setup TLS on Ingress |
 | metrics.ingress.tls | list | `[]` |  |
 | metrics.jobs.register | list | `[]` | String list of datasets that should be registered right at startup |
+| metrics.port | int | `8080` | Container port to bind |
 | metrics.resources.limits.memory | string | `"40Mi"` |  |
 | metrics.resources.requests.cpu | string | `"20m"` |  |
 | metrics.resources.requests.memory | string | `"20Mi"` |  |
@@ -48,11 +49,13 @@ Current chart version is `0.4.2`
 | securityContext | object | `{"allowPrivilegeEscalation":true,"privileged":true}` | The current image requires to run privileged in order to access ZFS |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
-| serviceAccount.name | string | `nil` | If not set and create is true, a name is generated using the fullname template |
-| ssh.config | string | `nil` | ssh_config(5)-compatible file content to configure SSH options when connecting |
-| ssh.externalSecretName | string | `nil` | Set this value if you provide your own secret with SSH config |
-| ssh.identities | object | `{}` | Provide a private key for each SSH identity, see values.yaml for an example |
-| ssh.knownHosts | string | `nil` | List of {host, pubKey} dicts where the public key of each host is configured |
+| serviceAccount.name | string | `""` | If not set and create is true, a name is generated using the fullname template |
+| ssh.config | string | `""` | `ssh_config(5)`-compatible file content to configure SSH options when connecting |
+| ssh.externalSecretName | string | `""` | Set this value if you provide your own secret with SSH config |
+| ssh.identities | object | `{}` | Provide a private key for each SSH identity, see [values.yaml](./values.yaml) for an example |
+| ssh.knownHosts | list | `[]` | List of `{host, pubKey}` dicts where the public key of each host is configured |
 | ssh.path | string | `"/root/.ssh"` | Path where your SSH config and identities get mounted in the container |
 | tolerations | list | `[]` |  |
 | znapzend.args | list | `["znapzend","--logto=/dev/stdout","--autoCreation"]` | List of command arguments |
+| znapzend.backupPlans | list | `[]` | List of backup plans to create/ensure on startup, see [values.yaml](./values.yaml) for an example |
+| znapzend.reloadPlans | bool | `true` | Whether znapzend should reload the `znapzend.backupPlans` after modifying them. Creates additional RBAC roles for the `serviceAccount.name` |

--- a/znapzend/templates/_helpers.tpl
+++ b/znapzend/templates/_helpers.tpl
@@ -61,3 +61,33 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Define SelfReset
+*/}}
+{{- define "metrics.selfReset" -}}
+SelfResetAfter={{ default "1h" .selfResetAfter }}
+{{- end -}}
+
+{{/*
+Common Volumes
+*/}}
+{{- define "znapzend.volumes" -}}
+- name: zfs
+  hostPath:
+    path: "{{ .Values.host.zfsDevice }}"
+    type: CharDevice
+{{ $secretName := include "znapzend.fullname" . }}
+{{- with .Values.ssh -}}
+{{- if or .identities .externalSecretName }}
+- name: ssh
+  secret:
+    {{- if .externalSecretName }}
+    secretName: {{ .externalSecretName }}
+    {{- else }}
+    secretName: {{ $secretName }}
+    {{- end }}
+    defaultMode: 0600
+{{- end }}
+{{- end }}
+{{- end }}

--- a/znapzend/templates/configmap.yaml
+++ b/znapzend/templates/configmap.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.znapzend.backupPlans -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "znapzend.fullname" . }}-backup-plans
+  labels:
+    {{- include "znapzend.labels" . | nindent 4 }}
+data:
+  {{- range $index, $plan := .Values.znapzend.backupPlans }}
+  plan{{ $index }}: {{ if $plan.custom }}{{ toYaml $plan.custom | indent 2 }}{{ else }}|
+    enabled={{ default "on" $plan.plan.enabled }}
+    src_plan={{ $plan.plan.source.retention }}
+    {{- range $index, $value := $plan.plan.targets }}
+    dst_{{ $index }}={{ $value.host }}:{{ $value.dataset }}
+    dst_{{ $index}}_plan={{ $value.retention }}
+    {{- if $.Values.metrics.enabled }}
+    dst_{{ $index }}_precmd=/usr/bin/curl -sS localhost:{{ $.Values.metrics.port }}/presend/{{ $plan.dataset }}
+    dst_{{ $index }}_pstcmd=/usr/bin/curl -sS localhost:{{ $.Values.metrics.port }}/postsend/{{ $plan.dataset }}?{{ include "metrics.selfReset" $plan.plan }}
+    {{- end }}
+    {{- end }}
+    {{- if $.Values.metrics.enabled }}
+    pre_znap_cmd=/usr/bin/curl -sS localhost:{{ $.Values.metrics.port }}/presnap/{{ $plan.dataset }}
+    post_znap_cmd=/usr/bin/curl -sS localhost:{{ $.Values.metrics.port }}/postsnap/{{ $plan.dataset }}{{- if not $plan.plan.targets }}?{{ include "metrics.selfReset" $plan.plan }}{{- end }}
+    {{- end }}
+    recursive={{- if $plan.plan.source.recursive }}on{{ else }}off{{- end }}
+    tsformat={{ default "%Y-%m-%d-%H%M%S" $plan.plan.tsFormat }}
+    mbuffer_size={{ default "1G" $plan.plan.mbufferSize }}
+    mbuffer={{ default "off" $plan.plan.mbuffer }}
+    zend_delay={{ default 0 $plan.plan.delaySeconds }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/znapzend/templates/job.yaml
+++ b/znapzend/templates/job.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/hook: post-install,post-upgrade
 spec:
   backoffLimit: 2
-  ttlSecondsAfterFinished: 172800 # After 2 days, nobody cares about the logs of the job anymore.
+  ttlSecondsAfterFinished: 172800 # 2 days
   template:
     spec:
       serviceAccountName: {{ include "znapzend.serviceAccountName" . }}
@@ -43,7 +43,7 @@ spec:
               mountPath: /etc/znapzend
             - name: success
               mountPath: /tmp/znapzend
-        {{- if .Values.znapzend.reloadPlans -}}
+        {{- if .Values.znapzend.reloadPlans }}
         - name: reload-znapzend
           image: "docker.io/bitnami/kubectl:1.17"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/znapzend/templates/job.yaml
+++ b/znapzend/templates/job.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.znapzend.backupPlans -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "znapzend.fullname" . }}-backup-plans
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 172800 # After 2 days, nobody cares about the logs of the job anymore.
+  template:
+    spec:
+      serviceAccountName: {{ include "znapzend.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      containers:
+        - name: znapzendzetup
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.env }}
+          env:
+          {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value }}
+          {{- end }}
+          {{- end }}
+          args:
+            - |
+              set -e &&
+              {{- range $index, $plan := .Values.znapzend.backupPlans }}
+              znapzendzetup import --write {{ $plan.dataset }} /etc/znapzend/plan{{ $index }} &&
+              {{- end }}
+              echo "$?" > /tmp/znapzend/success
+          volumeMounts:
+            - name: zfs
+              mountPath: /dev/zfs
+            {{- if or .Values.ssh.identities .Values.ssh.externalSecretName }}
+            - name: ssh
+              mountPath: {{ .Values.ssh.path }}
+            {{- end }}
+            - name: backup-plans
+              mountPath: /etc/znapzend
+            - name: success
+              mountPath: /tmp/znapzend
+        {{- if .Values.znapzend.reloadPlans -}}
+        - name: reload-znapzend
+          image: "docker.io/bitnami/kubectl:1.17"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - |
+              set -e
+              echo "waiting until backup plans are imported..."
+              until [ -f /tmp/znapzend/success ]; do
+                printf . && sleep 2
+              done
+              if [ $(cat /tmp/znapzend/success) == "0" ]; then
+                pod=$(kubectl get pods -o name -l app.kubernetes.io/name={{ include "znapzend.name" . }} | head -n 1)
+                kubectl exec -c znapzend "$pod" -- pkill -HUP znapzend
+              else
+                echo "Import failed"
+                exit 1
+              fi
+          volumeMounts:
+            - name: success
+              mountPath: /tmp/znapzend
+        {{- end }}
+      volumes:
+        {{- include "znapzend.volumes" . | nindent 8 }}
+        - name: backup-plans
+          configMap:
+            name: {{ include "znapzend.fullname" . }}-backup-plans
+        - name: success
+          emptyDir: {}
+{{- end }}

--- a/znapzend/templates/rbac.yaml
+++ b/znapzend/templates/rbac.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.znapzend.backupPlans .Values.znapzend.reloadPlans -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "znapzend.fullname" . }}-pod-exec-role
+  labels:
+    {{- include "znapzend.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "znapzend.fullname" . }}-pod-exec-binding
+  labels:
+    {{- include "znapzend.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "znapzend.fullname" . }}-pod-exec-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "znapzend.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/znapzend/templates/statefulset.yaml
+++ b/znapzend/templates/statefulset.yaml
@@ -61,7 +61,9 @@ spec:
           imagePullPolicy: {{ .image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ .port }}
+          args:
+            - --bindAddr=:{{ .port }}
           env:
           {{- if .jobs.register }}
             - name: JOBS_REGISTER
@@ -102,20 +104,4 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       volumes:
-        - name: zfs
-          hostPath:
-            path: "{{ .Values.host.zfsDevice }}"
-            type: CharDevice
-        {{ $secretName := include "znapzend.fullname" . }}
-        {{- with .Values.ssh }}
-        {{- if or .identities .externalSecretName }}
-        - name: ssh
-          secret:
-            {{- if .externalSecretName }}
-            secretName: {{ .externalSecretName }}
-            {{- else }}
-            secretName: {{ $secretName }}
-            {{- end }}
-            defaultMode: 0600
-        {{- end }}
-        {{- end }}
+        {{- include "znapzend.volumes" . | nindent 8 -}}

--- a/znapzend/test/configmap_test.go
+++ b/znapzend/test/configmap_test.go
@@ -1,0 +1,130 @@
+package test
+
+import (
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+var tplConfigMap = []string{"templates/configmap.yaml"}
+
+func Test_ConfigMap_GivenBackupPlans_WhenCustomField_ThenRenderCustomFile(t *testing.T) {
+	options := &helm.Options{
+		ValuesFiles: []string{"values/configmap_1.yaml"},
+	}
+
+	expectedContent := "mycustomcontent=invalid-znapzend-config"
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplConfigMap)
+
+	var configmap v1.ConfigMap
+	helm.UnmarshalK8SYaml(t, output, &configmap)
+
+	assert.Equal(t, expectedContent, configmap.Data["plan0"])
+
+}
+
+func Test_ConfigMap_GivenPlanField_WhenMinimalConfig_ThenRenderPlanWithDefaults(t *testing.T) {
+	options := &helm.Options{
+		ValuesFiles: []string{"values/configmap_2.yaml"},
+		SetValues: map[string]string{
+			"metrics.enabled": "false",
+		},
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplConfigMap)
+
+	var configmap v1.ConfigMap
+	helm.UnmarshalK8SYaml(t, output, &configmap)
+
+	plan := configmap.Data["plan0"]
+	expectedPlan := `enabled=on
+src_plan=1days=>2hours,2weeks=>1days,6months=>1weeks
+recursive=off
+tsformat=%Y-%m-%d-%H%M%S
+mbuffer_size=1G
+mbuffer=off
+zend_delay=0`
+
+	assert.Equal(t, expectedPlan, plan)
+}
+
+func Test_ConfigMap_GivenPlanField_WhenMetricsEnabled_ThenRenderSourceWithReset(t *testing.T) {
+	options := &helm.Options{
+		ValuesFiles: []string{"values/configmap_2.yaml"},
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplConfigMap)
+
+	var configmap v1.ConfigMap
+	helm.UnmarshalK8SYaml(t, output, &configmap)
+
+	plan := configmap.Data["plan0"]
+	expectedPlan := `enabled=on
+src_plan=1days=>2hours,2weeks=>1days,6months=>1weeks
+pre_znap_cmd=/usr/bin/curl -sS localhost:8080/presnap/tank/test/dataset
+post_znap_cmd=/usr/bin/curl -sS localhost:8080/postsnap/tank/test/dataset?SelfResetAfter=5m
+recursive=off
+tsformat=%Y-%m-%d-%H%M%S
+mbuffer_size=1G
+mbuffer=off
+zend_delay=0`
+
+	assert.Equal(t, expectedPlan, plan)
+}
+
+func Test_ConfigMap_GivenPlanField_WhenTargetsGiven_ThenRenderTargets(t *testing.T) {
+	options := &helm.Options{
+		ValuesFiles: []string{"values/configmap_3.yaml"},
+		SetValues: map[string]string{
+			"metrics.enabled": "false",
+		},
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplConfigMap)
+
+	var configmap v1.ConfigMap
+	helm.UnmarshalK8SYaml(t, output, &configmap)
+
+	plan := configmap.Data["plan0"]
+	expectedPlan := `enabled=on
+src_plan=1days=>2hours,2weeks=>1days,6months=>1weeks
+dst_0=target.host:backup/target
+dst_0_plan=1days=>2hours
+recursive=on
+tsformat=%Y-%m-%d-%H%M%S
+mbuffer_size=1G
+mbuffer=off
+zend_delay=600`
+
+	assert.Equal(t, expectedPlan, plan)
+}
+
+func Test_ConfigMap_GivenPlanField_WhenTargetsAndMetricsGiven_ThenRenderTargetsWithMetrics(t *testing.T) {
+	options := &helm.Options{
+		ValuesFiles: []string{"values/configmap_3.yaml"},
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplConfigMap)
+
+	var configmap v1.ConfigMap
+	helm.UnmarshalK8SYaml(t, output, &configmap)
+
+	plan := configmap.Data["plan0"]
+	expectedPlan := `enabled=on
+src_plan=1days=>2hours,2weeks=>1days,6months=>1weeks
+dst_0=target.host:backup/target
+dst_0_plan=1days=>2hours
+dst_0_precmd=/usr/bin/curl -sS localhost:8080/presend/tank/test/dataset
+dst_0_pstcmd=/usr/bin/curl -sS localhost:8080/postsend/tank/test/dataset?SelfResetAfter=1h
+pre_znap_cmd=/usr/bin/curl -sS localhost:8080/presnap/tank/test/dataset
+post_znap_cmd=/usr/bin/curl -sS localhost:8080/postsnap/tank/test/dataset
+recursive=on
+tsformat=%Y-%m-%d-%H%M%S
+mbuffer_size=1G
+mbuffer=off
+zend_delay=600`
+
+	assert.Equal(t, expectedPlan, plan)
+}

--- a/znapzend/test/job_test.go
+++ b/znapzend/test/job_test.go
@@ -1,0 +1,71 @@
+package test
+
+import (
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+var tplJob = []string{"templates/job.yaml"}
+
+func Test_Job_GivenBackupPlans_WhenEnabled_ThenRenderEnvironmentVariables(t *testing.T) {
+	options := &helm.Options{
+		ValuesFiles: []string{"values/job_1.yaml"},
+	}
+
+	expectedKeys := []string{"KEY1", "ANOTHER_KEY"}
+	expectedValues := []string{"value", "another value"}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplJob)
+
+	var job batchv1.Job
+	helm.UnmarshalK8SYaml(t, output, &job)
+
+	envs := job.Spec.Template.Spec.Containers[0].Env
+	for i, _ := range envs {
+		require.Contains(t, envs, v1.EnvVar{
+			Name:  expectedKeys[i],
+			Value: expectedValues[i],
+		})
+	}
+}
+
+func Test_Job_GivenBackupPlans_WhenSshIdentitiesProvided_ThenRenderVolumes(t *testing.T) {
+	options := &helm.Options{
+		ValuesFiles: []string{"values/job_2.yaml"},
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplJob)
+
+	var job batchv1.Job
+	helm.UnmarshalK8SYaml(t, output, &job)
+
+	volumeMounts := job.Spec.Template.Spec.Containers[0].VolumeMounts
+	assertSshVolumeMounts(t, volumeMounts)
+
+	volumes := job.Spec.Template.Spec.Volumes
+	assertSshVolume(t, volumes)
+}
+
+func Test_Job_GivenBackupPlans_WhenMultiplePlans_ThenRenderCommandArgs(t *testing.T) {
+	options := &helm.Options{
+		ValuesFiles: []string{"values/job_2.yaml"},
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplJob)
+
+	var job batchv1.Job
+	helm.UnmarshalK8SYaml(t, output, &job)
+
+	args := job.Spec.Template.Spec.Containers[0].Args
+	expectedArgs := `set -e &&
+znapzendzetup import --write pool/dataset1 /etc/znapzend/plan0 &&
+znapzendzetup import --write pool/dataset2 /etc/znapzend/plan1 &&
+echo "$?" > /tmp/znapzend/success
+`
+
+	assert.Equal(t, args[0], expectedArgs)
+}

--- a/znapzend/test/main_test.go
+++ b/znapzend/test/main_test.go
@@ -1,6 +1,35 @@
 package test
 
+import (
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"testing"
+)
+
 var (
 	helmChartPath = ".."
 	releaseName = "test-release"
 )
+
+func assertSshVolume(t *testing.T, volumes []v1.Volume) {
+	require.Contains(t, volumes, v1.Volume{
+		Name: "ssh",
+		VolumeSource: v1.VolumeSource{
+			Secret: &v1.SecretVolumeSource{
+				SecretName:  releaseName + "-znapzend",
+				DefaultMode: getIntPointer(0600),
+			},
+		},
+	})
+}
+
+func assertSshVolumeMounts(t *testing.T, volumeMounts []v1.VolumeMount) {
+	require.Contains(t, volumeMounts, v1.VolumeMount{
+		Name:      "zfs",
+		MountPath: "/dev/zfs",
+	})
+	require.Contains(t, volumeMounts, v1.VolumeMount{
+		Name:      "ssh",
+		MountPath: "/root/.ssh",
+	})
+}

--- a/znapzend/test/statefulset_test.go
+++ b/znapzend/test/statefulset_test.go
@@ -45,25 +45,10 @@ func Test_StatefulSet_ShouldRender_SshVolumes_IfEnabled(t *testing.T) {
 	helm.UnmarshalK8SYaml(t, output, &statefulset)
 
 	volumeMounts := statefulset.Spec.Template.Spec.Containers[0].VolumeMounts
-	require.Contains(t, volumeMounts, v1.VolumeMount{
-		Name:      "zfs",
-		MountPath: "/dev/zfs",
-	})
-	require.Contains(t, volumeMounts, v1.VolumeMount{
-		Name:      "ssh",
-		MountPath: "/root/.ssh",
-	})
+	assertSshVolumeMounts(t, volumeMounts)
 
 	volumes := statefulset.Spec.Template.Spec.Volumes
-	require.Contains(t, volumes, v1.Volume{
-		Name: "ssh",
-		VolumeSource: v1.VolumeSource{
-			Secret: &v1.SecretVolumeSource{
-				SecretName:  releaseName + "-znapzend",
-				DefaultMode: getIntPointer(0600),
-			},
-		},
-	})
+	assertSshVolume(t, volumes)
 }
 
 func getIntPointer(mode int) *int32 {

--- a/znapzend/test/values/configmap_1.yaml
+++ b/znapzend/test/values/configmap_1.yaml
@@ -1,0 +1,4 @@
+znapzend:
+  backupPlans:
+  - custom: |
+      mycustomcontent=invalid-znapzend-config

--- a/znapzend/test/values/configmap_2.yaml
+++ b/znapzend/test/values/configmap_2.yaml
@@ -1,0 +1,7 @@
+znapzend:
+  backupPlans:
+  - dataset: tank/test/dataset
+    plan:
+      source:
+        retention: 1days=>2hours,2weeks=>1days,6months=>1weeks
+      selfResetAfter: 5m

--- a/znapzend/test/values/configmap_3.yaml
+++ b/znapzend/test/values/configmap_3.yaml
@@ -1,0 +1,12 @@
+znapzend:
+  backupPlans:
+  - dataset: tank/test/dataset
+    plan:
+      source:
+        retention: 1days=>2hours,2weeks=>1days,6months=>1weeks
+        recursive: true
+      targets:
+      - host: target.host
+        retention: 1days=>2hours
+        dataset: backup/target
+      delaySeconds: 600

--- a/znapzend/test/values/job_1.yaml
+++ b/znapzend/test/values/job_1.yaml
@@ -1,0 +1,8 @@
+env:
+  KEY1: value
+  ANOTHER_KEY: another value
+znapzend:
+  backupPlans:
+  - dataset: pool/dataset
+    custom: |
+      a plan

--- a/znapzend/test/values/job_2.yaml
+++ b/znapzend/test/values/job_2.yaml
@@ -1,0 +1,13 @@
+ssh:
+  identities:
+    id_rsa: |
+      ----BEGIN----
+      ----END----
+znapzend:
+  backupPlans:
+  - dataset: pool/dataset1
+    custom: |
+      a plan
+  - dataset: pool/dataset2
+    custom: |
+      a plan

--- a/znapzend/values.yaml
+++ b/znapzend/values.yaml
@@ -40,9 +40,9 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # serviceAccount.name -- If not set and create is true, a name is generated using the fullname template
-  name:
+  name: ""
 
-# env -- A dict with KEY: VALUE pairs
+# env -- A dict with `KEY: VALUE` pairs
 env: {}
 
 znapzend:
@@ -51,41 +51,69 @@ znapzend:
     - znapzend
     - --logto=/dev/stdout
     - --autoCreation
+  # znapzend.reloadPlans -- Whether znapzend should reload the `znapzend.backupPlans` after modifying
+  # them. Creates additional RBAC roles for the `serviceAccount.name`
+  reloadPlans: true
+  # znapzend.backupPlans -- List of backup plans to create/ensure on startup, see
+  # [values.yaml](./values.yaml) for an example
+  backupPlans: []
+  # - dataset: pool/dataset
+  ##  znapzend.backupPlans[].plan -- A backup plan object
+  #   plan:
+  #     selfResetAfter: 5m # Only effective when `metrics.enabled=true`, optional, default `1h`
+  #     delaySeconds: 600 # Optional, default `0`
+  #     source:
+  #       retention: 1days=>2hours,2weeks=>1days,6months=>1weeks
+  #       recursive: false # Optional, default `false`
+  #     targets:
+  #     - host: target.host
+  #       dataset: backup/dataset
+  #       retention: 1days=>2hours,2weeks=>1days,6months=>1weeks
+  #   custom: | # If you define this field, you can specify your own znapzend-compatible configuration
+  #     recursive=on
+  #     src_plan=1days=>2hours,2weeks=>1days,6months=>1weeks
+  #     tsformat=%Y-%m-%d-%H%M%S
+  #     mbuffer_size=1G
+  #     mbuffer=off
+  #     enabled=on
 
 host:
-  # host.zfsDevice -- The device on the host which is used by the 'zfs' binary within the container
+  # host.zfsDevice -- The device on the host which is used by the `zfs` binary within the container
   zfsDevice: /dev/zfs
 
 ssh:
   # ssh.path -- Path where your SSH config and identities get mounted in the container
   path: /root/.ssh
-  # ssh.config -- ssh_config(5)-compatible file content to configure SSH options when connecting
-  config:
+  # ssh.config -- `ssh_config(5)`-compatible file content to configure SSH options when connecting
+  config: ""
 # config: |
 #   Host my-host
 #     IdentityFile ~/.ssh/my-id
 #     User myuser
   # ssh.externalSecretName -- Set this value if you provide your own secret with SSH config
-  externalSecretName:
-  # ssh.identities -- Provide a private key for each SSH identity, see values.yaml for an example
+  externalSecretName: ""
+  # ssh.identities -- Provide a private key for each SSH identity, see
+  # [values.yaml](./values.yaml) for an example
   identities: {}
 #   id_ed25519: |
 #     -----BEGIN OPENSSH PRIVATE KEY-----
 #     ...
 #     -----END OPENSSH PRIVATE KEY-----
-  # ssh.knownHosts -- List of {host, pubKey} dicts where the public key of each host is configured
-  knownHosts:
+  # ssh.knownHosts -- List of `{host, pubKey}` dicts where the public key of each host is configured
+  knownHosts: []
 #   - host: my-host
 #     pubKey: ssh-ed25519 AAAAC3NzaC...
 
 metrics:
-  # metrics.enabled -- Enable the znapzend metrics exporter for Prometheus
+  # metrics.enabled -- Enable the metrics exporter for Prometheus
   enabled: true
   jobs:
     # metrics.jobs.register -- String list of datasets that should be registered right at startup
     register: []
-  # metrics.env -- A dict with KEY: VALUE pairs as environment variables for the exporter
+  # metrics.env -- A dict with `KEY: VALUE` pairs as environment variables for the exporter
   env: {}
+  # metrics.port -- Container port to bind
+  port: 8080
 
   image:
     # metrics.image.repository -- Exporter image repository
@@ -108,12 +136,11 @@ metrics:
     # metrics.ingress.enabled -- Useful if your Prometheus is outside of the cluster
     enabled: false
     annotations: {}
-      # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     # metrics.ingress.hosts -- See Kubernetes Docs for a guide to setup Ingress hosts
-    hosts:
-      - host:
-        paths: []
+    hosts: []
+    # - host:
+    #   paths: []
     # metrics.ingress.hosts -- See Kubernetes Docs for a guide to setup TLS on Ingress
     tls: []
     #  - secretName: chart-example-tls


### PR DESCRIPTION
<!--
Thank you for contributing to ccremer/charts. Before you submit this PR I'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Please make sure that you let https://github.com/norwoodj/helm-docs generate the
documentation. You can do that by running

    make docs

This will create README.md files based on the values.yaml file.
-->

#### What this PR does / why we need it:

* Adds ConfigMap entry with znapzend-compatible configuration
* Runs a Job to configure znapzendzetup with the backup plans

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata). Run `make docs` to generate the README.md.
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
