### PR TITLE
[kubernetes-zfs-provisioner] Render string if no parameter is given

### DIFF
--- a/kubernetes-zfs-provisioner/Chart.yaml
+++ b/kubernetes-zfs-provisioner/Chart.yaml
@@ -14,7 +14,7 @@ description: Dynamic ZFS persistent volume provisioner for Kubernetes
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/kubernetes-zfs-provisioner/README.md
+++ b/kubernetes-zfs-provisioner/README.md
@@ -2,7 +2,7 @@ kubernetes-zfs-provisioner
 ==========================
 Dynamic ZFS persistent volume provisioner for Kubernetes
 
-Current chart version is `0.2.4`
+Current chart version is `0.2.5`
 
 
 

--- a/kubernetes-zfs-provisioner/templates/storageclass.yaml
+++ b/kubernetes-zfs-provisioner/templates/storageclass.yaml
@@ -14,6 +14,6 @@ parameters:
   hostname: {{ .hostName }}
   type: {{ .type | default "nfs" }}
   node: {{ .nodeName | default "''" }}
-  shareProperties: {{ .shareProperties | default "" }}
+  shareProperties: {{ .shareProperties | default "''" }}
 {{- end }}
 {{- end }}

--- a/kubernetes-zfs-provisioner/test/storageclass_test.go
+++ b/kubernetes-zfs-provisioner/test/storageclass_test.go
@@ -27,7 +27,7 @@ func Test_Storageclass_GivenClassesEnabled_WhenNoPolicyDefined_ThenRenderDefault
 	assert.Equal(t, &expectedPolicy, class.ReclaimPolicy)
 }
 
-func Test_Secret_GivenClassesEnabled_WhenNoTypeDefined_ThenRenderDefault(t *testing.T) {
+func Test_StorageClass_GivenClassesEnabled_WhenNoTypeDefined_ThenRenderDefault(t *testing.T) {
 	options := &helm.Options{
 		SetValues: map[string]string{
 			"storageClass.create":          "true",
@@ -43,7 +43,7 @@ func Test_Secret_GivenClassesEnabled_WhenNoTypeDefined_ThenRenderDefault(t *test
 	assert.Equal(t, "nfs", class.Parameters["type"])
 }
 
-func Test_Secret_GivenClassesEnabled_WhenAdditionalParametersUndefined_ThenRenderEmptyValues(t *testing.T) {
+func Test_StorageClass_GivenClassesEnabled_WhenAdditionalParametersUndefined_ThenRenderEmptyValues(t *testing.T) {
 	options := &helm.Options{
 		SetValues: map[string]string{
 			"storageClass.create":                     "true",


### PR DESCRIPTION


<!--
Thank you for contributing to ccremer/charts. Before you submit this PR I'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Please make sure that you let https://github.com/norwoodj/helm-docs generate the
documentation. You can do that by running

    make docs

This will create README.md files based on the values.yaml file.
-->

#### What this PR does / why we need it:

* renders an empty value of shareProperties as empty string, not nil. Otherwise Kubernetes fails at validating if the value is empty,
since it would be rendered as nil.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata). Run `make docs` to generate the README.md.
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
