### PR TITLE
[kubernetes-zfs-provisioner] Fix wrong Node parameter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,20 +19,6 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Update chart versions
-        if: "!contains(github.event.head_commit.message, 'skip bump')"
-        run: make bump-docs
-
-      - name: Commit changes
-        if: "!contains(github.event.head_commit.message, 'skip bump')"
-        uses: EndBug/add-and-commit@v4
-        with:
-          author_name: "${{ github.actor }}"
-          author_email: "${{ github.actor }}@users.noreply.github.com"
-          message: "Update chart versions"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@master
         env:

--- a/kubernetes-zfs-provisioner/Chart.yaml
+++ b/kubernetes-zfs-provisioner/Chart.yaml
@@ -14,7 +14,7 @@ description: Dynamic ZFS persistent volume provisioner for Kubernetes
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.6
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/kubernetes-zfs-provisioner/README.md
+++ b/kubernetes-zfs-provisioner/README.md
@@ -2,7 +2,7 @@ kubernetes-zfs-provisioner
 ==========================
 Dynamic ZFS persistent volume provisioner for Kubernetes
 
-Current chart version is `0.2.6`
+Current chart version is `0.2.7`
 
 
 

--- a/kubernetes-zfs-provisioner/templates/storageclass.yaml
+++ b/kubernetes-zfs-provisioner/templates/storageclass.yaml
@@ -13,7 +13,7 @@ parameters:
   parentDataset: {{ .parentDataset }}
   hostname: {{ .hostName }}
   type: {{ .type | default "nfs" }}
-  node: {{ .nodeName | default "''" }}
+  node: {{ .node | default "''" }}
   shareProperties: {{ .shareProperties | default "''" }}
 {{- end }}
 {{- end }}

--- a/kubernetes-zfs-provisioner/test/storageclass_test.go
+++ b/kubernetes-zfs-provisioner/test/storageclass_test.go
@@ -43,6 +43,24 @@ func Test_StorageClass_GivenClassesEnabled_WhenNoTypeDefined_ThenRenderDefault(t
 	assert.Equal(t, "nfs", class.Parameters["type"])
 }
 
+func Test_StorageClass_GivenClassesEnabled_WhenNodeDefined_ThenRenderNodeName(t *testing.T) {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"storageClass.create":          "true",
+			"storageClass.classes[0].node": "host",
+			"storageClass.classes[0].type": "hostpath",
+		},
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplStorageclass)
+
+	var class v1.StorageClass
+	helm.UnmarshalK8SYaml(t, output, &class)
+
+	assert.Equal(t, "host", class.Parameters["node"])
+	assert.Equal(t, "hostpath", class.Parameters["type"])
+}
+
 func Test_StorageClass_GivenClassesEnabled_WhenAdditionalParametersUndefined_ThenRenderEmptyValues(t *testing.T) {
 	options := &helm.Options{
 		SetValues: map[string]string{


### PR DESCRIPTION
<!--
Thank you for contributing to ccremer/charts. Before you submit this PR I'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

Please make sure that you let https://github.com/norwoodj/helm-docs generate the
documentation. You can do that by running

    make docs

This will create README.md files based on the values.yaml file.
-->

#### What this PR does / why we need it:

* Fix a nasty bug, includes test case
* Removes the steps to commit Chart bumps from Workflow, it creates confusion.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata). Run `make docs` to generate the README.md.
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
