### PR TITLE
[zfs-provisioner] Bump to v1

### DIFF
--- a/.github/readme.sh
+++ b/.github/readme.sh
@@ -14,7 +14,7 @@ copy_documentation() {
 
 find . -type f -name Chart.yaml | cut -s -f 3 -d / - | copy_documentation
 
-make readme TARGET_README="${gh_pages_worktree}/README.md" MASTER_BRANCH=false
+make docs:readme TARGET_README="${gh_pages_worktree}/README.md" MASTER_BRANCH=false
 
 pushd "${gh_pages_worktree}" > /dev/null
 

--- a/charts/kubernetes-zfs-provisioner/Chart.yaml
+++ b/charts/kubernetes-zfs-provisioner/Chart.yaml
@@ -14,10 +14,11 @@ description: Dynamic ZFS persistent volume provisioner for Kubernetes
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.8
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.2.1
+#appVersion: see image.tag
+
 # Licensing of https://commons.wikimedia.org/wiki/File:Openzfs.svg applies
 icon: https://upload.wikimedia.org/wikipedia/commons/thumb/7/7f/Openzfs.svg/257px-Openzfs.svg.png

--- a/charts/kubernetes-zfs-provisioner/README.gotmpl.md
+++ b/charts/kubernetes-zfs-provisioner/README.gotmpl.md
@@ -1,0 +1,9 @@
+## Upgrading from 0.x charts
+
+There are some breaking changes from 0.x to 1.x versions.
+
+* The `storageclass.classes` array is now empty.
+  Where it previously contained an example, the example is removed as a default value.
+  The example is still in `values.yaml` in form of YAML comments.
+* The `image.registry` has changed from `docker.io` to `quay.io` due to Docker Hub's pull limit.
+* Bumped `image.tag` to `v1.0.0`

--- a/charts/kubernetes-zfs-provisioner/README.md
+++ b/charts/kubernetes-zfs-provisioner/README.md
@@ -1,6 +1,6 @@
 # kubernetes-zfs-provisioner
 
-![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square) ![AppVersion: 0.2.1](https://img.shields.io/badge/AppVersion-0.2.1-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)
 
 Dynamic ZFS persistent volume provisioner for Kubernetes
 
@@ -10,6 +10,15 @@ Dynamic ZFS persistent volume provisioner for Kubernetes
 helm repo add ccremer https://ccremer.github.io/charts
 helm install kubernetes-zfs-provisioner ccremer/kubernetes-zfs-provisioner
 ```
+## Upgrading from 0.x charts
+
+There are some breaking changes from 0.x to 1.x versions.
+
+* The `storageclass.classes` array is now empty.
+  Where it previously contained an example, the example is removed as a default value.
+  The example is still in `values.yaml` in form of YAML comments.
+* The `image.registry` has changed from `docker.io` to `quay.io` due to Docker Hub's pull limit.
+* Bumped `image.tag` to `v1.0.0`
 
 ## Values
 
@@ -19,9 +28,9 @@ helm install kubernetes-zfs-provisioner ccremer/kubernetes-zfs-provisioner
 | env | object | `{}` | A dict with KEY: VALUE pairs |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.registry | string | `"docker.io"` | Container image registry |
+| image.registry | string | `"quay.io"` | Container image registry |
 | image.repository | string | `"ccremer/zfs-provisioner"` | Location of the container image |
-| image.tag | string | `"v0.3.0"` | Container image tag |
+| image.tag | string | `"v1.0.0"` | Container image tag |
 | imagePullSecrets | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Reminder: This has no effect on any PVs, but maybe you want the provisioner pod running on certain nodes. |
@@ -41,12 +50,6 @@ helm install kubernetes-zfs-provisioner ccremer/kubernetes-zfs-provisioner
 | ssh.identities | object | `{}` | **Required.** Provide a private key for each SSH identity, see values.yaml for an example |
 | ssh.knownHosts | list | `[]` | **Required.** List of {host, pubKey} dicts where the public key of each host is configured |
 | ssh.mountPath | string | `"/home/zfs/.ssh"` | The path where the SSH config and identities are mounted |
-| storageClass.classes[0].hostName | string | `"storage-1.domain.tld"` | The provisioners connects through SSH to this ZFS host |
-| storageClass.classes[0].name | string | `"zfs"` |  |
-| storageClass.classes[0].node | string | `""` | Override `kubernetes.io/hostname` from `hostName` parameter for `HostPath` node affinity |
-| storageClass.classes[0].parentDataset | string | `"tank/kubernetes"` | Existing dataset on the target ZFS host |
-| storageClass.classes[0].policy | string | `"Delete"` | The reclaim policy supported by the provisioner |
-| storageClass.classes[0].shareProperties | string | `""` | NFS export properties (see `exports(5)`) |
-| storageClass.classes[0].type | string | `"nfs"` | Provision type, one of [`nfs`, `hostpath`] |
-| storageClass.create | bool | `false` | Whether to create storage classes for this provisioner. One example is given in the `classes` array |
+| storageClass.classes | list | `[]` | Storage classes to create. See [values.yaml](values.yaml) for an example. |
+| storageClass.create | bool | `false` | Whether to create storage classes for this provisioner. |
 | tolerations | list | `[]` |  |

--- a/charts/kubernetes-zfs-provisioner/test/storageclass_test.go
+++ b/charts/kubernetes-zfs-provisioner/test/storageclass_test.go
@@ -12,10 +12,9 @@ import (
 var tplStorageclass = []string{"templates/storageclass.yaml"}
 
 func Test_Storageclass_GivenClassesEnabled_WhenNoPolicyDefined_ThenRenderDefault(t *testing.T) {
-	t.Skipf("Skipping for now. Chart is due for breaking changes")
 	options := &helm.Options{
+		ValuesFiles: []string{"values/storageclass_1.yaml"},
 		SetValues: map[string]string{
-			"storageClass.create":            "true",
 			"storageClass.classes[0].policy": "",
 		},
 	}
@@ -30,12 +29,8 @@ func Test_Storageclass_GivenClassesEnabled_WhenNoPolicyDefined_ThenRenderDefault
 }
 
 func Test_StorageClass_GivenClassesEnabled_WhenNoTypeDefined_ThenRenderDefault(t *testing.T) {
-	t.Skipf("Skipping for now. Chart is due for breaking changes")
 	options := &helm.Options{
-		SetValues: map[string]string{
-			"storageClass.create":          "true",
-			"storageClass.classes[0].type": "",
-		},
+		ValuesFiles: []string{"values/storageclass_1.yaml"},
 	}
 
 	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplStorageclass)
@@ -65,10 +60,9 @@ func Test_StorageClass_GivenClassesEnabled_WhenNodeDefined_ThenRenderNodeName(t 
 }
 
 func Test_StorageClass_GivenClassesEnabled_WhenAdditionalParametersUndefined_ThenRenderEmptyValues(t *testing.T) {
-	t.Skipf("Skipping for now. Chart is due for breaking changes")
 	options := &helm.Options{
+		ValuesFiles: []string{"values/storageclass_1.yaml"},
 		SetValues: map[string]string{
-			"storageClass.create":                     "true",
 			"storageClass.classes[0].node":            "",
 			"storageClass.classes[0].shareProperties": "",
 		},

--- a/charts/kubernetes-zfs-provisioner/test/values/storageclass_1.yaml
+++ b/charts/kubernetes-zfs-provisioner/test/values/storageclass_1.yaml
@@ -1,0 +1,4 @@
+storageClass:
+  create: true
+  classes:
+    - name: test

--- a/charts/kubernetes-zfs-provisioner/values.yaml
+++ b/charts/kubernetes-zfs-provisioner/values.yaml
@@ -9,9 +9,9 @@ image:
   # -- Location of the container image
   repository: ccremer/zfs-provisioner
   # -- Container image registry
-  registry: docker.io
+  registry: quay.io
   # -- Container image tag
-  tag: v0.3.0
+  tag: v1.0.0
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -24,24 +24,24 @@ provisioner:
   instance: pv.kubernetes.io/zfs
 
 storageClass:
-  # -- Whether to create storage classes for this provisioner. One example is given
-  # in the `classes` array
+  # -- Whether to create storage classes for this provisioner.
   create: false
-  classes:
-    - name: zfs
-      # -- The provisioners connects through SSH to this ZFS host
-      hostName: storage-1.domain.tld
-      # -- Existing dataset on the target ZFS host
-      parentDataset: tank/kubernetes
-      # -- The reclaim policy supported by the provisioner
-      policy: "Delete"
-      # -- NFS export properties (see `exports(5)`)
-      shareProperties: ""
-      # -- Provision type, one of [`nfs`, `hostpath`]
-      type: "nfs"
-      # -- Override `kubernetes.io/hostname` from `hostName` parameter for
-      # `HostPath` node affinity
-      node: ""
+  # -- Storage classes to create. See [values.yaml](values.yaml) for an example.
+  classes: []
+    # - name: zfs
+    #   # -- The provisioners connects through SSH to this ZFS host
+    #   hostName: storage-1.domain.tld
+    #   # -- Existing dataset on the target ZFS host
+    #   parentDataset: tank/kubernetes
+    #   # -- The reclaim policy supported by the provisioner
+    #   policy: "Delete"
+    #   # -- NFS export properties (see `exports(5)`)
+    #   shareProperties: ""
+    #   # -- Provision type, one of [`nfs`, `hostpath`]
+    #   type: "nfs"
+    #   # -- Override `kubernetes.io/hostname` from `hostName` parameter for
+    #   # `HostPath` node affinity
+    #   node: ""
 
 ssh:
   # -- If SSH secrets are managed externally, specify the name


### PR DESCRIPTION
#### What this PR does / why we need it:

* Updates zfs-kubernetes-provisioner to v1, making it stable API

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make lint docs` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
