### PR TITLE
[samba] Add initial version of samba helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 * [emby](charts/emby/README.md)
 * [fronius-exporter](charts/fronius-exporter/README.md)
 * [kubernetes-zfs-provisioner](charts/kubernetes-zfs-provisioner/README.md)
+* [samba](charts/samba/README.md)
 * [znapzend](charts/znapzend/README.md)
 
 ## Development

--- a/charts/samba/.helmignore
+++ b/charts/samba/.helmignore
@@ -1,0 +1,27 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+# Unit tests
+test/
+*gotmpl*

--- a/charts/samba/Chart.yaml
+++ b/charts/samba/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: samba
+description: A Helm chart for Samba server
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: latest
+sources:
+  - https://github.com/dperson/samba

--- a/charts/samba/README.gotmpl.md
+++ b/charts/samba/README.gotmpl.md
@@ -1,0 +1,7 @@
+## Limitations
+
+`samba.shares` and `samba.users` are translated into indexed environment variables, e.g. `SHARE0` and `USER0`.
+Unfortunately, there cannot be an 11th share or user definition, as `SHARE10` gets confused with `SHARE1` (and likewise with `USERx`).
+
+To workaround this limitation, use the `samba.args` and construct the definitions on your own using the script arguments.
+Refer to [dperson/samba](https://github.com/dperson/samba) on how to do this.

--- a/charts/samba/README.md
+++ b/charts/samba/README.md
@@ -1,0 +1,60 @@
+# samba
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+
+A Helm chart for Samba server
+
+## Installation
+
+```bash
+helm repo add ccremer https://ccremer.github.io/charts
+helm install samba ccremer/samba
+```
+## Limitations
+
+`samba.shares` and `samba.users` are translated into indexed environment variables, e.g. `SHARE0` and `USER0`.
+Unfortunately, there cannot be an 11th share or user definition, as `SHARE10` gets confused with `SHARE1` (and likewise with `USERx`).
+
+To workaround this limitation, use the `samba.args` and construct the definitions on your own using the script arguments.
+Refer to [dperson/samba](https://github.com/dperson/samba) on how to do this.
+
+## Source Code
+
+* <https://github.com/dperson/samba>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"Always"` |  |
+| image.registry | string | `"docker.io"` |  |
+| image.repository | string | `"dperson/samba"` |  |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| imagePullSecrets | list | `[]` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| persistence.annotations | object | `{}` | Additional annotations to add to the PVC |
+| persistence.enabled | bool | `false` | Whether a PVC shall be created |
+| persistence.mountPath | string | `"/data"` |  |
+| persistence.selector | object | `{}` | PV selector |
+| persistence.size | string | `"8Gi"` | Size of the PVC |
+| persistence.storageClass | string | `""` | Storage Class name of the PV |
+| persistence.volumeMounts | list | `[]` | Additional volume mounts, regardless of `enabled`. See [values.yaml](values.yaml) for an example. |
+| persistence.volumes | list | `[]` | Additional volumes, regardless of `enabled`. See [values.yaml](values.yaml) for an example. |
+| podAnnotations | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| replicaCount | int | `1` | Be sure to make use of tolerations or affinity rules if you scale higher than 1. |
+| resources.limits.memory | string | `"512Mi"` |  |
+| resources.requests.cpu | string | `"30m"` |  |
+| resources.requests.memory | string | `"64Mi"` |  |
+| samba.args | list | `[]` | Container args to pass |
+| samba.rawEnv | object | `{}` | A dict with KEY: VALUE entries to directly define environment variables. |
+| samba.shares | list | `[]` | A list of Samba shares. Convenience wrapper around SHARE env var(s). See [values.yaml](values.yaml) for an example. |
+| samba.users | list | `[]` | A list of users as a convenience wrapper around USER env var(s). See [values.yaml](values.yaml) for an example. |
+| securityContext | object | `{}` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| tolerations | list | `[]` |  |

--- a/charts/samba/templates/_helpers.tpl
+++ b/charts/samba/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "samba.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "samba.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "samba.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "samba.labels" -}}
+helm.sh/chart: {{ include "samba.chart" . }}
+{{ include "samba.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "samba.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "samba.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "samba.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "samba.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/samba/templates/configmap.yaml
+++ b/charts/samba/templates/configmap.yaml
@@ -1,0 +1,17 @@
+{{- if or .Values.samba.rawEnv .Values.samba.shares }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "samba.fullname" . }}
+  labels:
+    {{- include "samba.labels" . | nindent 4 }}
+data:
+{{- range $key, $value := .Values.samba.rawEnv }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- range $index, $share := .Values.samba.shares }}
+  {{- with $share }}
+  SHARE{{ $index }}: {{ printf "%s;%s;%s;%s;%s;%s;%s;%s;%s" .name .path (default "" .browsable) (default "" .readonly) (default "" .guest) (default "" .users) (default "" .admins) (default "" .writelist) (default "" .comment) | quote }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/samba/templates/deployment.yaml
+++ b/charts/samba/templates/deployment.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "samba.fullname" . }}
+  labels:
+    {{- include "samba.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "samba.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        configmap.kubernetes.io/checksum: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        secret.kubernetes.io/checksum: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "samba.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "samba.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            {{- toYaml .Values.samba.args | nindent 12 }}
+          envFrom:
+          {{- if or .Values.samba.rawEnv .Values.samba.shares }}
+            - configMapRef:
+                name: {{ include "samba.fullname" . }}
+          {{- end }}
+          {{- if .Values.samba.users }}
+            - secretRef:
+                name: {{ include "samba.fullname" . }}
+          {{- end }}
+          ports:
+            - name: smb
+              containerPort: 445
+              hostPort: 445
+              protocol: TCP
+            - name: nmb
+              containerPort: 139
+              hostPort: 139
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: smb
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+          {{- end }}
+          {{- with .Values.persistence.volumeMounts }}
+            {{- toYaml .Values.persistence.volumeMounts | nindent 12 }}
+          {{- end }}
+      volumes:
+      {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "samba.fullname" . }}-data
+      {{- end }}
+      {{- with .Values.persistence.volumes }}
+        {{- toYaml .Values.persistence.volumes | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/samba/templates/pvc.yaml
+++ b/charts/samba/templates/pvc.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.persistence.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "samba.fullname" . }}-data
+  labels:
+    {{- include "samba.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- with .Values.persistence.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/samba/templates/secret.yaml
+++ b/charts/samba/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.samba.users }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "samba.fullname" . }}
+  labels:
+    {{- include "samba.labels" . | nindent 4 }}
+stringData:
+{{- range $index, $user := .Values.samba.users }}
+  {{- with $user }}
+  USER{{ $index }}: {{ printf "%s;%s;%v;%s;%v" .username .password (default "" .id) (default "" .group) (default "" .gid) | quote }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/samba/templates/serviceaccount.yaml
+++ b/charts/samba/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "samba.serviceAccountName" . }}
+  labels:
+    {{- include "samba.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/samba/values.yaml
+++ b/charts/samba/values.yaml
@@ -1,0 +1,102 @@
+# Default values for samba.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Be sure to make use of tolerations or affinity rules if you scale higher than 1.
+replicaCount: 1
+
+samba:
+  # -- A dict with KEY: VALUE entries to directly define environment variables.
+  rawEnv: {}
+  # -- A list of users as a convenience wrapper around USER env var(s). See [values.yaml](values.yaml) for an example.
+  users: []
+  # - username: myusername # REQUIRED
+  #   password: mypassword # REQUIRED
+  #   id: 1000 # user id
+  #   group: smbusers # group name
+  #   gid: 1000 # group id
+
+  # -- A list of Samba shares. Convenience wrapper around SHARE env var(s). See [values.yaml](values.yaml) for an example.
+  shares: []
+  # - name: share # is how it's called for clients, REQUIRED
+  #   path: /share # REQUIRED
+  #   browsable: "yes" # default: blank string (uses image default)
+  #   readonly: "yes" # default: blank string (uses image default)
+  #   guest: "yes" # default: blank string (uses image default)
+  #   users: "all" # comma-separated list of allowed users
+  #   admins: "none" # comma-separated list of admin users
+  #   writelist: "" # list of users that can write to a RO share
+  #   comment: "" # description of share
+
+  # -- Container args to pass
+  args: []
+
+image:
+  registry: docker.io
+  repository: dperson/samba
+  pullPolicy: Always
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+persistence:
+  # -- Whether a PVC shall be created
+  enabled: false
+  # -- Size of the PVC
+  size: 8Gi
+  mountPath: /data
+  # -- PV selector
+  selector: {}
+  # -- Storage Class name of the PV
+  storageClass: ""
+  # -- Additional annotations to add to the PVC
+  annotations: {}
+
+  # -- Additional volume mounts, regardless of `enabled`. See [values.yaml](values.yaml) for an example.
+  volumeMounts: []
+  #  - name: myvol
+  #    mountPath: /myvol
+
+  # -- Additional volumes, regardless of `enabled`. See [values.yaml](values.yaml) for an example.
+  volumes: []
+  #  - name: myvol
+  #    emptyDir: {}
+
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources:
+  limits:
+    memory: 512Mi
+  requests:
+    cpu: 30m
+    memory: 64Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

* Add new Samba helm chart
* Easily allow declarative user and shares definitions
* Add persistent storage
* Based on https://github.com/dperson/samba

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make lint docs` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
