### PR TITLE
[samba] Fix additional volume mount

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,6 @@
 #### Checklist
 <!-- Place an '[x]' (no spaces) in all applicable fields. -->
 - [ ] Chart Version bumped
-- [ ] `make lint docs` passes
+- [ ] `make docs lint` passes
 - [ ] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
 - [ ] Title of the PR contains starts with chart name e.g. `[chart]`

--- a/charts/samba/Chart.yaml
+++ b/charts/samba/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/samba/README.md
+++ b/charts/samba/README.md
@@ -1,6 +1,6 @@
 # samba
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A Helm chart for Samba server
 

--- a/charts/samba/templates/deployment.yaml
+++ b/charts/samba/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
               mountPath: {{ .Values.persistence.mountPath }}
           {{- end }}
           {{- with .Values.persistence.volumeMounts }}
-            {{- toYaml .Values.persistence.volumeMounts | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
       {{- if .Values.persistence.enabled }}
@@ -75,7 +75,7 @@ spec:
             claimName: {{ include "samba.fullname" . }}-data
       {{- end }}
       {{- with .Values.persistence.volumes }}
-        {{- toYaml .Values.persistence.volumes | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
 
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
#### What this PR does / why we need it:

* Fixes a template error: executing "samba/templates/deployment.yaml" at <.Values.persistence.volumeMounts>: can't evaluate field Values in type []interface {}

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make lint docs` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
