### PR TITLE
[fronius-exporter] Update fronius-exporter to v0.4.0

### DIFF
--- a/charts/fronius-exporter/Chart.yaml
+++ b/charts/fronius-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fronius-exporter/README.md
+++ b/charts/fronius-exporter/README.md
@@ -1,6 +1,6 @@
 # fronius-exporter
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Prometheus Exporter for Fronius Symo Photovoltaics
 
@@ -27,9 +27,9 @@ helm install fronius-exporter ccremer/fronius-exporter
 | fronius.url | string | `"http://symo.ip.or.hostname/solar_api/v1/GetPowerFlowRealtimeData.fcgi"` | Target URL of Fronius SYMO device. **Required** |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.registry | string | `"docker.io"` | Container image registry |
+| image.registry | string | `"quay.io"` | Container image registry |
 | image.repository | string | `"ccremer/fronius-exporter"` | Location of the container image |
-| image.tag | string | `"v0.3.0"` | Container image tag |
+| image.tag | string | `"v0.4.0"` | Container image tag |
 | imagePullSecrets | list | `[]` | List of image pull secrets if you use a privately hosted image |
 | ingress.annotations | object | `{}` | Additional annotations for the Ingress object |
 | ingress.enabled | bool | `false` | Useful if your Prometheus is outside of the cluster |

--- a/charts/fronius-exporter/values.yaml
+++ b/charts/fronius-exporter/values.yaml
@@ -7,11 +7,11 @@ replicaCount: 1
 
 image:
   # -- Container image registry
-  registry: docker.io
+  registry: quay.io
   # -- Location of the container image
   repository: ccremer/fronius-exporter
   # -- Container image tag
-  tag: "v0.3.0"
+  tag: "v0.4.0"
   pullPolicy: IfNotPresent
 
 # -- List of image pull secrets if you use a privately hosted image


### PR DESCRIPTION
#### What this PR does / why we need it:

* Update fronius-exporter to v0.4.0
* Switch to quay.io as default registry

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make docs lint` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
