### PR TITLE
[zfs-provisioner] Add possibility to configure Host Aliases

### DIFF
--- a/charts/kubernetes-zfs-provisioner/Chart.yaml
+++ b/charts/kubernetes-zfs-provisioner/Chart.yaml
@@ -14,7 +14,7 @@ description: Dynamic ZFS persistent volume provisioner for Kubernetes
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/kubernetes-zfs-provisioner/README.md
+++ b/charts/kubernetes-zfs-provisioner/README.md
@@ -1,6 +1,6 @@
 # kubernetes-zfs-provisioner
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square)
 
 Dynamic ZFS persistent volume provisioner for Kubernetes
 
@@ -27,6 +27,7 @@ There are some breaking changes from 0.x to 1.x versions.
 | affinity | object | `{}` |  |
 | env | object | `{}` | A dict with KEY: VALUE pairs |
 | fullnameOverride | string | `""` |  |
+| hostAliases | object | `{}` | A dict with `{ip, hostnames array}` to configure custom entries in /etc/hosts. See [values.yaml](./values.yaml) for an example. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"quay.io"` | Container image registry |
 | image.repository | string | `"ccremer/zfs-provisioner"` | Location of the container image |
@@ -47,7 +48,7 @@ There are some breaking changes from 0.x to 1.x versions.
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | ssh.config | string | `""` | **Required.** ssh_config(5)-compatible file content to configure SSH options when connecting |
 | ssh.externalSecretName | string | `""` | If SSH secrets are managed externally, specify the name |
-| ssh.identities | object | `{}` | **Required.** Provide a private key for each SSH identity, see values.yaml for an example |
+| ssh.identities | object | `{}` | **Required.** Provide a private key for each SSH identity. See [values.yaml](./values.yaml) for an example |
 | ssh.knownHosts | list | `[]` | **Required.** List of {host, pubKey} dicts where the public key of each host is configured |
 | ssh.mountPath | string | `"/home/zfs/.ssh"` | The path where the SSH config and identities are mounted |
 | storageClass.classes | list | `[]` | Storage classes to create. See [values.yaml](values.yaml) for an example. |

--- a/charts/kubernetes-zfs-provisioner/templates/deployment.yaml
+++ b/charts/kubernetes-zfs-provisioner/templates/deployment.yaml
@@ -44,6 +44,16 @@ spec:
               mountPath: {{ .Values.ssh.mountPath }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+      {{- range $ip, $hostnames := . }}
+        - ip: {{ $ip }}
+          hostnames:
+          {{- range . }}
+            - {{ . }}
+          {{- end }}
+      {{- end }}
+      {{- end }}
       volumes:
         {{- with .Values.ssh }}
         - name: ssh

--- a/charts/kubernetes-zfs-provisioner/values.yaml
+++ b/charts/kubernetes-zfs-provisioner/values.yaml
@@ -55,7 +55,8 @@ ssh:
     #     IdentityFile ~/.ssh/id_ed25519
     #     User zfs
 
-  # -- **Required.** Provide a private key for each SSH identity, see values.yaml for an example
+  # -- **Required.** Provide a private key for each SSH identity.
+  # See [values.yaml](./values.yaml) for an example
   identities: {}
 #   id_ed25519: |
 #     -----BEGIN OPENSSH PRIVATE KEY-----
@@ -69,6 +70,12 @@ ssh:
 
 # -- A dict with KEY: VALUE pairs
 env: {}
+
+# -- A dict with `{ip, hostnames array}` to configure custom entries in /etc/hosts.
+# See [values.yaml](./values.yaml) for an example.
+hostAliases: {}
+#  192.168.1.1:
+#    - my-custom-host.name
 
 serviceAccount:
   # -- Specifies whether a service account should be created


### PR DESCRIPTION
#### What this PR does / why we need it:

* Add possibility to configure Host Aliases

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make docs lint` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
