### PR TITLE
[fronius-exporter] Add possibility to configure hostAliases

### DIFF
--- a/charts/fronius-exporter/Chart.yaml
+++ b/charts/fronius-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fronius-exporter/README.md
+++ b/charts/fronius-exporter/README.md
@@ -1,6 +1,6 @@
 # fronius-exporter
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Prometheus Exporter for Fronius Symo Photovoltaics
 
@@ -26,6 +26,7 @@ helm install fronius-exporter ccremer/fronius-exporter
 | fronius.timeoutSeconds | int | `5` | Time after which collecting may time out. Should not be higher than the Prometheus scrape interval. |
 | fronius.url | string | `"http://symo.ip.or.hostname/solar_api/v1/GetPowerFlowRealtimeData.fcgi"` | Target URL of Fronius SYMO device. **Required** |
 | fullnameOverride | string | `""` |  |
+| hostAliases | object | `{}` | A dict with `{ip, hostnames array}` to configure custom entries in /etc/hosts. See [values.yaml](./values.yaml) for an example. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"quay.io"` | Container image registry |
 | image.repository | string | `"ccremer/fronius-exporter"` | Location of the container image |

--- a/charts/fronius-exporter/README.md
+++ b/charts/fronius-exporter/README.md
@@ -22,9 +22,9 @@ helm install fronius-exporter ccremer/fronius-exporter
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| fronius.additionalArgs | list | `[]` | Provide additional CLI flags via string array |
-| fronius.timeoutSeconds | int | `5` | Time after which collecting may time out. Should not be higher than the Prometheus scrape interval. |
-| fronius.url | string | `"http://symo.ip.or.hostname/solar_api/v1/GetPowerFlowRealtimeData.fcgi"` | Target URL of Fronius SYMO device. **Required** |
+| exporter.additionalArgs | list | `[]` | Provide additional CLI flags via string array |
+| exporter.symoUrl | string | `"http://symo.ip.or.hostname/solar_api/v1/GetPowerFlowRealtimeData.fcgi"` | Target URL of Fronius SYMO device. **Required** |
+| exporter.timeoutSeconds | int | `5` | Time after which collecting may time out. Should not be higher than the Prometheus scrape interval. |
 | fullnameOverride | string | `""` |  |
 | hostAliases | object | `{}` | A dict with `{ip, hostnames array}` to configure custom entries in /etc/hosts. See [values.yaml](./values.yaml) for an example. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/fronius-exporter/templates/deployment.yaml
+++ b/charts/fronius-exporter/templates/deployment.yaml
@@ -47,6 +47,16 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+      {{- range $ip, $hostnames := . }}
+        - ip: {{ $ip }}
+          hostnames:
+          {{- range . }}
+            - {{ . }}
+          {{- end }}
+      {{- end }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/fronius-exporter/templates/deployment.yaml
+++ b/charts/fronius-exporter/templates/deployment.yaml
@@ -32,9 +32,9 @@ spec:
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - --symo.url={{ .Values.fronius.url }}
-            - --symo.timeout={{ .Values.fronius.timeoutSeconds }}
-            {{- range .Values.fronius.additionalArgs }}
+            - --symo.url={{ .Values.exporter.symoUrl }}
+            - --symo.timeout={{ .Values.exporter.timeoutSeconds }}
+            {{- range .Values.exporter.additionalArgs }}
             - {{ . }}
             {{- end }}
           ports:

--- a/charts/fronius-exporter/test/deployment_test.go
+++ b/charts/fronius-exporter/test/deployment_test.go
@@ -13,7 +13,7 @@ var tplDeployment = []string{"templates/deployment.yaml"}
 func Test_Deployment_GivenTimeoutOverridden_ThenRenderNewValue(t *testing.T) {
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"fronius.timeoutSeconds": "3",
+			"exporter.timeoutSeconds": "3",
 		},
 	}
 

--- a/charts/fronius-exporter/test/values/deployment_1.yaml
+++ b/charts/fronius-exporter/test/values/deployment_1.yaml
@@ -1,4 +1,4 @@
-fronius:
+exporter:
   additionalArgs:
     - --arg1
     - --arg2=key=value

--- a/charts/fronius-exporter/values.yaml
+++ b/charts/fronius-exporter/values.yaml
@@ -19,9 +19,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-fronius:
+exporter:
   # -- Target URL of Fronius SYMO device. **Required**
-  url: "http://symo.ip.or.hostname/solar_api/v1/GetPowerFlowRealtimeData.fcgi"
+  symoUrl: "http://symo.ip.or.hostname/solar_api/v1/GetPowerFlowRealtimeData.fcgi"
   # -- Provide additional CLI flags via string array
   additionalArgs: []
   # -- Time after which collecting may time out. Should not be higher than

--- a/charts/fronius-exporter/values.yaml
+++ b/charts/fronius-exporter/values.yaml
@@ -41,6 +41,12 @@ podAnnotations: {}
 
 podSecurityContext: {}
 
+# -- A dict with `{ip, hostnames array}` to configure custom entries in /etc/hosts.
+# See [values.yaml](./values.yaml) for an example.
+hostAliases: {}
+#  192.168.1.1:
+#    - my-custom-host.name
+
 securityContext: {}
   # capabilities:
   #   drop:


### PR DESCRIPTION
#### What this PR does / why we need it:

* Add possibility to configure hostAliases
* Rename `fronius:*` to `exporter.*`

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make docs lint` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
