### PR TITLE
[fronius-exporter] Add Telegraf sidecar

### DIFF
--- a/charts/fronius-exporter/Chart.yaml
+++ b/charts/fronius-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fronius-exporter/README.md
+++ b/charts/fronius-exporter/README.md
@@ -1,6 +1,6 @@
 # fronius-exporter
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Prometheus Exporter for Fronius Symo Photovoltaics
 
@@ -52,4 +52,13 @@ helm install fronius-exporter ccremer/fronius-exporter
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and `create` is `true`, a name is generated using the fullname template |
+| telegraf.enabled | bool | `true` | Whether to enable Telegraf sidecar for Influxdb |
+| telegraf.image.registry | string | `"docker.io"` |  |
+| telegraf.image.repository | string | `"library/telegraf"` | Telegraf image location |
+| telegraf.image.tag | string | `"1.18-alpine"` | Telegraf image tag |
+| telegraf.influxdb.bucket | string | `"fronius"` | Bucket to write metrics into |
+| telegraf.influxdb.organization | string | `"fronius"` | Organization where the bucket belongs to |
+| telegraf.influxdb.token | string | `""` | Token used to authenticate to InfluxDB |
+| telegraf.influxdb.url | string | `"http://influxdb2"` | URL of an InfluxDB 2 instance |
+| telegraf.interval | string | `"30s"` | Go-style interval in which metrics are pushed to InfluxDB |
 | tolerations | list | `[]` |  |

--- a/charts/fronius-exporter/templates/_helpers.tpl
+++ b/charts/fronius-exporter/templates/_helpers.tpl
@@ -61,3 +61,13 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Container images
+*/}}
+{{- define "fronius-exporter.image" -}}
+{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+{{- end }}
+{{- define "fronius-exporter.telegrafImage" -}}
+{{ .Values.telegraf.image.registry }}/{{ .Values.telegraf.image.repository }}:{{ .Values.telegraf.image.tag }}
+{{- end }}

--- a/charts/fronius-exporter/templates/deployment.yaml
+++ b/charts/fronius-exporter/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - name: exporter
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ include "fronius-exporter.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --symo.url={{ .Values.exporter.symoUrl }}
@@ -48,6 +48,25 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.telegraf.enabled }}
+        - name: telegraf
+          image: {{ include "fronius-exporter.telegrafImage" . }}
+          resources:
+            limits:
+              cpu: 200m
+              memory: 200Mi
+            requests:
+              cpu: 10m
+              memory: 10Mi
+          volumeMounts:
+            - name: telegraf-config
+              mountPath: /etc/telegraf
+      volumes:
+        - name: telegraf-config
+          secret:
+            secretName: {{ template "fronius-exporter.fullname" . }}
+            defaultMode: 420
+      {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:
       {{- range $ip, $hostnames := . }}

--- a/charts/fronius-exporter/templates/telegraf-secret.yaml
+++ b/charts/fronius-exporter/templates/telegraf-secret.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.telegraf.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fronius-exporter.fullname" . }}
+  labels:
+    {{- include "fronius-exporter.labels" . | nindent 4 }}
+stringData:
+  telegraf.conf: |
+    [[inputs.prometheus]]
+      urls = ["http://localhost:8080/metrics"]
+      interval = {{ .Values.telegraf.interval | quote }}
+    [[outputs.influxdb_v2]]
+      urls = [{{ .Values.telegraf.influxdb.url | quote }}]
+      token = {{ .Values.telegraf.influxdb.token | quote }}
+      organization = {{ .Values.telegraf.influxdb.organization | quote }}
+      bucket = {{ .Values.telegraf.influxdb.bucket | quote }}
+    [global_tags]
+      hostname = "$HOSTNAME"
+{{- end -}}

--- a/charts/fronius-exporter/values.yaml
+++ b/charts/fronius-exporter/values.yaml
@@ -30,6 +30,27 @@ exporter:
   # the Prometheus scrape interval.
   timeoutSeconds: 5
 
+telegraf:
+  # -- Whether to enable Telegraf sidecar for Influxdb
+  enabled: true
+  # -- Go-style interval in which metrics are pushed to InfluxDB
+  interval: 30s
+  image:
+    registry: docker.io
+    # -- Telegraf image location
+    repository: library/telegraf
+    # -- Telegraf image tag
+    tag: 1.18-alpine
+  influxdb:
+    # -- URL of an InfluxDB 2 instance
+    url: http://influxdb2
+    # -- Token used to authenticate to InfluxDB
+    token: ""
+    # -- Bucket to write metrics into
+    bucket: fronius
+    # -- Organization where the bucket belongs to
+    organization: fronius
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
#### What this PR does / why we need it:

* Adds a Telegraf sidecar and config to the exporter deployment. Disabled by default.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make docs lint` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
