### PR TITLE
[fronius-exporter] Remove quotes, remove url field

### DIFF
--- a/charts/fronius-exporter/Chart.yaml
+++ b/charts/fronius-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fronius-exporter/README.md
+++ b/charts/fronius-exporter/README.md
@@ -1,6 +1,6 @@
 # fronius-exporter
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Prometheus Exporter for Fronius Symo Photovoltaics
 

--- a/charts/fronius-exporter/templates/deployment.yaml
+++ b/charts/fronius-exporter/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --symo.url={{ .Values.exporter.symoUrl }}
-            - --symo.site={{ .Values.exporter.siteName | quote }}
+            - --symo.site={{ .Values.exporter.siteName }}
             - --symo.timeout={{ .Values.exporter.timeoutSeconds }}
             {{- range .Values.exporter.additionalArgs }}
             - {{ . }}

--- a/charts/fronius-exporter/templates/telegraf-secret.yaml
+++ b/charts/fronius-exporter/templates/telegraf-secret.yaml
@@ -10,6 +10,7 @@ stringData:
     [[inputs.prometheus]]
       urls = ["http://localhost:8080/metrics"]
       interval = {{ .Values.telegraf.interval | quote }}
+      fielddrop = ["url"]
     [[outputs.influxdb_v2]]
       urls = [{{ .Values.telegraf.influxdb.url | quote }}]
       token = {{ .Values.telegraf.influxdb.token | quote }}


### PR DESCRIPTION
#### What this PR does / why we need it:

* Drop url field from Telegraf metrics, as it's largely useless in a sidecar
* Remove quotes from site name

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make docs lint` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
