### PR TITLE
[fronius-exporter] Add global tags support

### DIFF
--- a/charts/fronius-exporter/Chart.yaml
+++ b/charts/fronius-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fronius-exporter/README.md
+++ b/charts/fronius-exporter/README.md
@@ -1,6 +1,6 @@
 # fronius-exporter
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Prometheus Exporter for Fronius Symo Photovoltaics
 
@@ -53,6 +53,7 @@ helm install fronius-exporter ccremer/fronius-exporter
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and `create` is `true`, a name is generated using the fullname template |
 | telegraf.enabled | bool | `true` | Whether to enable Telegraf sidecar for Influxdb |
+| telegraf.globalTags | object | `{}` | A dict with `key: value` to add to `global_tags` config |
 | telegraf.image.registry | string | `"docker.io"` |  |
 | telegraf.image.repository | string | `"library/telegraf"` | Telegraf image location |
 | telegraf.image.tag | string | `"1.18-alpine"` | Telegraf image tag |

--- a/charts/fronius-exporter/README.md
+++ b/charts/fronius-exporter/README.md
@@ -31,7 +31,7 @@ helm install fronius-exporter ccremer/fronius-exporter
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"quay.io"` | Container image registry |
 | image.repository | string | `"ccremer/fronius-exporter"` | Location of the container image |
-| image.tag | string | `"v0.5.0"` | Container image tag |
+| image.tag | string | `"v0.6.0"` | Container image tag |
 | imagePullSecrets | list | `[]` | List of image pull secrets if you use a privately hosted image |
 | ingress.annotations | object | `{}` | Additional annotations for the Ingress object |
 | ingress.enabled | bool | `false` | Useful if your Prometheus is outside of the cluster |

--- a/charts/fronius-exporter/templates/telegraf-secret.yaml
+++ b/charts/fronius-exporter/templates/telegraf-secret.yaml
@@ -10,12 +10,15 @@ stringData:
     [[inputs.prometheus]]
       urls = ["http://localhost:8080/metrics"]
       interval = {{ .Values.telegraf.interval | quote }}
-      fielddrop = ["url"]
     [[outputs.influxdb_v2]]
       urls = [{{ .Values.telegraf.influxdb.url | quote }}]
       token = {{ .Values.telegraf.influxdb.token | quote }}
       organization = {{ .Values.telegraf.influxdb.organization | quote }}
       bucket = {{ .Values.telegraf.influxdb.bucket | quote }}
+    {{- with .Values.telegraf.globalTags }}
     [global_tags]
-      hostname = "$HOSTNAME"
+    {{- range $key,$value := . }}
+      {{ $key }} = {{ $value }}
+    {{- end }}
+    {{- end }}
 {{- end -}}

--- a/charts/fronius-exporter/test/telegraf_secret_test.go
+++ b/charts/fronius-exporter/test/telegraf_secret_test.go
@@ -1,0 +1,43 @@
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	tplTelegrafSecret = []string{"templates/telegraf-secret.yaml"}
+)
+
+func Test_TelegrafSecret_WhenDefiningGlobalTags_ThenRenderEachKeyValue(t *testing.T) {
+	options := &helm.Options{
+		ValuesFiles: []string{"values/telegraf_1.yaml"},
+	}
+
+	expectedLine1 := "key1 = value1"
+	expectedLine2 := "key2 = value2"
+	expectedSection := "[global_tags]"
+	config := "telegraf.conf"
+	secret := renderSecret(t, options, false, tplTelegrafSecret)
+
+	assert.True(t, strings.Contains(secret.StringData[config], expectedLine1))
+	assert.True(t, strings.Contains(secret.StringData[config], expectedLine2))
+	assert.True(t, strings.Contains(secret.StringData[config], expectedSection))
+}
+
+func renderSecret(t *testing.T, options *helm.Options, wantErr bool, paths []string) *corev1.Secret {
+	output, err := helm.RenderTemplateE(t, options, helmChartPath, releaseName, paths)
+	if wantErr {
+		require.Error(t, err)
+		return nil
+	}
+	require.NoError(t, err)
+	subject := corev1.Secret{}
+	helm.UnmarshalK8SYaml(t, output, &subject)
+	return &subject
+}

--- a/charts/fronius-exporter/test/values/telegraf_1.yaml
+++ b/charts/fronius-exporter/test/values/telegraf_1.yaml
@@ -1,0 +1,4 @@
+telegraf:
+  globalTags:
+    key1: value1
+    key2: value2

--- a/charts/fronius-exporter/values.yaml
+++ b/charts/fronius-exporter/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- Location of the container image
   repository: ccremer/fronius-exporter
   # -- Container image tag
-  tag: "v0.5.0"
+  tag: "v0.6.0"
   pullPolicy: IfNotPresent
 
 # -- List of image pull secrets if you use a privately hosted image

--- a/charts/fronius-exporter/values.yaml
+++ b/charts/fronius-exporter/values.yaml
@@ -50,6 +50,8 @@ telegraf:
     bucket: fronius
     # -- Organization where the bucket belongs to
     organization: fronius
+  # -- A dict with `key: value` to add to `global_tags` config
+  globalTags: {}
 
 serviceAccount:
   # -- Specifies whether a service account should be created


### PR DESCRIPTION
#### What this PR does / why we need it:

* Removes the hostname tag (since Telegraf already adds the `host` field anyway)
* Removes the fielddrop config (wasn't working)
* Adds possibility to define custom global tags

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make docs lint` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
