### PR TITLE
[fronius-exporter] Disable telegraf sidecar by default, remove site parameter

### DIFF
--- a/charts/fronius-exporter/Chart.yaml
+++ b/charts/fronius-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fronius-exporter/Chart.yaml
+++ b/charts/fronius-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fronius-exporter/README.md
+++ b/charts/fronius-exporter/README.md
@@ -1,6 +1,6 @@
 # fronius-exporter
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Prometheus Exporter for Fronius Symo Photovoltaics
 
@@ -52,7 +52,7 @@ helm install fronius-exporter ccremer/fronius-exporter
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and `create` is `true`, a name is generated using the fullname template |
-| telegraf.enabled | bool | `true` | Whether to enable Telegraf sidecar for Influxdb |
+| telegraf.enabled | bool | `false` | Whether to enable Telegraf sidecar for Influxdb |
 | telegraf.globalTags | object | `{}` | A dict with `key: value` to add to `global_tags` config |
 | telegraf.image.registry | string | `"docker.io"` |  |
 | telegraf.image.repository | string | `"library/telegraf"` | Telegraf image location |

--- a/charts/fronius-exporter/README.md
+++ b/charts/fronius-exporter/README.md
@@ -1,6 +1,6 @@
 # fronius-exporter
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Prometheus Exporter for Fronius Symo Photovoltaics
 
@@ -23,7 +23,6 @@ helm install fronius-exporter ccremer/fronius-exporter
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | exporter.additionalArgs | list | `[]` | Provide additional CLI flags via string array |
-| exporter.siteName | string | `""` | Site name of Fronius SYMO that gets added as a static label to all metrics. **Recommended** |
 | exporter.symoUrl | string | `"http://symo.ip.or.hostname/solar_api/v1/GetPowerFlowRealtimeData.fcgi"` | Target URL of Fronius SYMO device. **Required** |
 | exporter.timeoutSeconds | int | `5` | Time after which collecting may time out. Should not be higher than the Prometheus scrape interval. |
 | fullnameOverride | string | `""` |  |

--- a/charts/fronius-exporter/templates/deployment.yaml
+++ b/charts/fronius-exporter/templates/deployment.yaml
@@ -38,7 +38,6 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --symo.url={{ .Values.exporter.symoUrl }}
-            - --symo.site={{ .Values.exporter.siteName }}
             - --symo.timeout={{ .Values.exporter.timeoutSeconds }}
             {{- range .Values.exporter.additionalArgs }}
             - {{ . }}

--- a/charts/fronius-exporter/templates/deployment.yaml
+++ b/charts/fronius-exporter/templates/deployment.yaml
@@ -11,10 +11,15 @@ spec:
       {{- include "fronius-exporter.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
+      {{- if or .Values.telegraf.enabled .Values.podAnnotations }}
       annotations:
+        {{- if .Values.telegraf.enabled }}
+        app.kubernetes.io/checksum: telegraf={{ include (print $.Template.BasePath "/telegraf-secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+        {{- end }}
+      {{- end }}
       labels:
         {{- include "fronius-exporter.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/fronius-exporter/templates/telegraf-secret.yaml
+++ b/charts/fronius-exporter/templates/telegraf-secret.yaml
@@ -18,7 +18,7 @@ stringData:
     {{- with .Values.telegraf.globalTags }}
     [global_tags]
     {{- range $key,$value := . }}
-      {{ $key }} = {{ $value }}
+      {{ $key }} = {{ $value | quote }}
     {{- end }}
     {{- end }}
 {{- end -}}

--- a/charts/fronius-exporter/values.yaml
+++ b/charts/fronius-exporter/values.yaml
@@ -22,8 +22,6 @@ fullnameOverride: ""
 exporter:
   # -- Target URL of Fronius SYMO device. **Required**
   symoUrl: "http://symo.ip.or.hostname/solar_api/v1/GetPowerFlowRealtimeData.fcgi"
-  # -- Site name of Fronius SYMO that gets added as a static label to all metrics. **Recommended**
-  siteName: ""
   # -- Provide additional CLI flags via string array
   additionalArgs: []
   # -- Time after which collecting may time out. Should not be higher than

--- a/charts/fronius-exporter/values.yaml
+++ b/charts/fronius-exporter/values.yaml
@@ -32,7 +32,7 @@ exporter:
 
 telegraf:
   # -- Whether to enable Telegraf sidecar for Influxdb
-  enabled: true
+  enabled: false
   # -- Go-style interval in which metrics are pushed to InfluxDB
   interval: 30s
   image:


### PR DESCRIPTION
#### What this PR does / why we need it:

* Remove site parameter and argument
* Ensure global tags are quoted
* Disable telegraf sidecar by default

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make docs lint` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
