### PR TITLE
[fronius-exporter] Add prometheus service monitor

### DIFF
--- a/charts/fronius-exporter/Chart.yaml
+++ b/charts/fronius-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fronius-exporter/README.gotmpl.md
+++ b/charts/fronius-exporter/README.gotmpl.md
@@ -1,0 +1,20 @@
+
+## Prometheus Operator
+
+This chart features templates for [Prometheus Operator][prometheus-operator] if desired.
+If you'd like to add additional Prometheus labels to all metrics, you could make use of relabelings:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  metricRelabelings:
+    - targetLabel: site
+      replacement: my-home
+```
+
+<!---
+Common/Useful Link references from values.yaml
+-->
+[resource-units]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+[prometheus-operator]: https://github.com/coreos/prometheus-operator
+[prom-relabel-config]: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig

--- a/charts/fronius-exporter/README.md
+++ b/charts/fronius-exporter/README.md
@@ -1,6 +1,6 @@
 # fronius-exporter
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Prometheus Exporter for Fronius Symo Photovoltaics
 
@@ -12,6 +12,26 @@ Prometheus Exporter for Fronius Symo Photovoltaics
 helm repo add ccremer https://ccremer.github.io/charts
 helm install fronius-exporter ccremer/fronius-exporter
 ```
+
+## Prometheus Operator
+
+This chart features templates for [Prometheus Operator][prometheus-operator] if desired.
+If you'd like to add additional Prometheus labels to all metrics, you could make use of relabelings:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  metricRelabelings:
+    - targetLabel: site
+      replacement: my-home
+```
+
+<!---
+Common/Useful Link references from values.yaml
+-->
+[resource-units]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+[prometheus-operator]: https://github.com/coreos/prometheus-operator
+[prom-relabel-config]: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
 
 ## Source Code
 
@@ -51,6 +71,11 @@ helm install fronius-exporter ccremer/fronius-exporter
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and `create` is `true`, a name is generated using the fullname template |
+| serviceMonitor.additionalLabels | object | `{}` | Add custom labels to the ServiceMonitor object |
+| serviceMonitor.enabled | bool | `false` | Deploy a ServiceMonitor object for Prometheus. Requires an installed [Prometheus Operator][prometheus-operator]. |
+| serviceMonitor.metricRelabelings | list | `[]` | Add relabeling configs before ingestion, see [RelabelConfig][prom-relabel-config]. |
+| serviceMonitor.namespace | string | `""` | Namespace in which to deploy the ServiceMonitor, defaults to release namespace. |
+| serviceMonitor.scrapeInterval | string | `""` | Override default scrape interval from Prometheus |
 | telegraf.enabled | bool | `false` | Whether to enable Telegraf sidecar for Influxdb |
 | telegraf.globalTags | object | `{}` | A dict with `key: value` to add to `global_tags` config |
 | telegraf.image.registry | string | `"docker.io"` |  |

--- a/charts/fronius-exporter/templates/prometheus/service-monitor.yaml
+++ b/charts/fronius-exporter/templates/prometheus/service-monitor.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "fronius-exporter.fullname" . }}-servicemonitor
+  namespace: {{ default .Release.Namespace .Values.serviceMonitor.namespace }}
+  labels:
+    {{- include "fronius-exporter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- if .Values.serviceMonitor.annotations }}
+  annotations:
+{{ toYaml .Values.serviceMonitor.annotations | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "fronius-exporter.selectorLabels" . | nindent 6 }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  {{- end }}
+  endpoints:
+    - path: /metrics
+      port: http
+      interval: {{ .Values.serviceMonitor.scrapeInterval }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end -}}

--- a/charts/fronius-exporter/test/telegraf_secret_test.go
+++ b/charts/fronius-exporter/test/telegraf_secret_test.go
@@ -19,8 +19,8 @@ func Test_TelegrafSecret_WhenDefiningGlobalTags_ThenRenderEachKeyValue(t *testin
 		ValuesFiles: []string{"values/telegraf_1.yaml"},
 	}
 
-	expectedLine1 := "key1 = value1"
-	expectedLine2 := "key2 = value2"
+	expectedLine1 := "key1 = \"value1\""
+	expectedLine2 := "key2 = \"value2\""
 	expectedSection := "[global_tags]"
 	config := "telegraf.conf"
 	secret := renderSecret(t, options, false, tplTelegrafSecret)

--- a/charts/fronius-exporter/test/values/telegraf_1.yaml
+++ b/charts/fronius-exporter/test/values/telegraf_1.yaml
@@ -1,4 +1,5 @@
 telegraf:
+  enabled: true
   globalTags:
     key1: value1
     key2: value2

--- a/charts/fronius-exporter/values.yaml
+++ b/charts/fronius-exporter/values.yaml
@@ -114,3 +114,15 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+serviceMonitor:
+  # -- Deploy a ServiceMonitor object for Prometheus. Requires an installed [Prometheus Operator][prometheus-operator].
+  enabled: false
+  # -- Namespace in which to deploy the ServiceMonitor, defaults to release namespace.
+  namespace: ""
+  # -- Override default scrape interval from Prometheus
+  scrapeInterval: ""
+  # -- Add relabeling configs before ingestion, see [RelabelConfig][prom-relabel-config].
+  metricRelabelings: []
+  # -- Add custom labels to the ServiceMonitor object
+  additionalLabels: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

* Short summary

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make docs lint` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
