### PR TITLE
[fronius-stack] Add Fronius stack chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 * [clustercode](charts/clustercode/README.md)
 * [emby](charts/emby/README.md)
 * [fronius-exporter](charts/fronius-exporter/README.md)
+* [fronius-stack](charts/fronius-stack/README.md)
 * [kubernetes-zfs-provisioner](charts/kubernetes-zfs-provisioner/README.md)
 * [samba](charts/samba/README.md)
 * [znapzend](charts/znapzend/README.md)

--- a/charts/fronius-stack/.helmignore
+++ b/charts/fronius-stack/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/fronius-stack/.helmignore
+++ b/charts/fronius-stack/.helmignore
@@ -21,3 +21,7 @@
 .idea/
 *.tmproj
 .vscode/
+
+# Unit tests
+test/
+*gotmpl*

--- a/charts/fronius-stack/.helmignore
+++ b/charts/fronius-stack/.helmignore
@@ -25,3 +25,5 @@
 # Unit tests
 test/
 *gotmpl*
+
+files/influxdb/migration

--- a/charts/fronius-stack/Chart.lock
+++ b/charts/fronius-stack/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: fronius-exporter
+  repository: https://ccremer.github.io/charts
+  version: 0.7.0
+- name: influxdb2
+  repository: https://helm.influxdata.com
+  version: 2.0.1
+digest: sha256:6e7967a5a8c8c1fc96bc87f8dd095d6b4b84a74397eb521ce2b38a1d0f71e0c7
+generated: "2021-06-13T15:07:45.092638342+02:00"

--- a/charts/fronius-stack/Chart.yaml
+++ b/charts/fronius-stack/Chart.yaml
@@ -1,0 +1,39 @@
+apiVersion: v2
+name: fronius-stack
+description: A Helm chart for installing fronius-exporter with long-term storage stack
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+#appVersion: "1.16.0"
+
+sources:
+  - https://github.com/ccremer/fronius-exporter
+
+dependencies:
+  - name: fronius-exporter
+    version: 0.6.0
+    repository: https://ccremer.github.io/charts
+    alias: fronius
+    condition: fronius.enabled
+  - name: influxdb2
+    alias: influxdb
+    version: 2.0.1
+    repository: https://helm.influxdata.com
+    condition: influxdb.enabled

--- a/charts/fronius-stack/Chart.yaml
+++ b/charts/fronius-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fronius-stack
-description: A Helm chart for installing fronius-exporter with long-term storage stack
+description: A Helm chart for installing fronius-exporter with long-term storage
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/charts/fronius-stack/Chart.yaml
+++ b/charts/fronius-stack/Chart.yaml
@@ -28,7 +28,7 @@ sources:
 
 dependencies:
   - name: fronius-exporter
-    version: 0.6.0
+    version: 0.7.0
     repository: https://ccremer.github.io/charts
     alias: fronius
     condition: fronius.enabled

--- a/charts/fronius-stack/README.gotmpl.md
+++ b/charts/fronius-stack/README.gotmpl.md
@@ -1,0 +1,70 @@
+> ⚠️ **WARNING**: See [data retention](#data-retention) first!
+
+## About
+
+This Helm chart installs the fronius-exporter along with long-term storage and a Grafana dashboard.
+The goal is to be able to do statistics of the photovoltaic installation.
+
+I wanted to keep fronius-exporter Helm chart minimal in case you're only interested in the exporter or you're bringing your own metrics stack.
+
+## Features
+
+* fronius-exporter chart
+* InfluxDB 2 chart
+  - Post-Install hook to configure archival bucket with downsampling
+* Grafana datasource
+* Grafana dashboard
+
+## Minimal required parameters
+
+You must configure following parameters in the minimum:
+
+```yaml
+influxdb:
+  adminUser:
+    token: changeme
+    password: changeme
+
+fronius:
+  exporter:
+    symoUrl: http://your.symo.device.or.ip/solar_api/v1/GetPowerFlowRealtimeData.fcgi
+  telegraf:
+    influxdb:
+      token: changeme # should to be the same as `influxdb.adminUser.token`!
+    globalTags:
+      site: my-home
+```
+
+## Data retention
+
+Before installing the chart, think about data retention.
+By default, the chart installs InfluxDB 2.0 with an initial bucket that keeps metrics for 14 days.
+
+Additionally, the chart features a one-time post-install hook to create an archival bucket that keeps data forever.
+It also creates a tasks that periodically downsamples the high-precision data to 10-minute-averages into the archival bucket.
+This bucket is meant to hold data for years.
+
+You can adjust retention with the following parameters:
+```console
+influxdb.adminUser.retention_policy
+archival.*
+```
+
+> ℹ️ **NOTE**: After installation, any changes in bucket namings, retention or downsampling settings will NOT be applied anymore.
+> You'd need to manually change this with InfluxDB CLI within the pod.
+
+## Grafana integration
+
+The chart comes with a Grafana datasource and dashboard ConfigMaps enabled by default.
+Please ensure Grafana sidecar is enabled and it searches in the release namespace, or set `grafana.*.namespace`.
+
+The dashboard features some panels that calculate per-day metrics.
+Make sure the Fronius Symo device, InfluxDB and Grafana dashboard are roughly in the same timezone.
+The Fronius Symo API includes counters like "energy per day" that reset at midnight.
+
+<!---
+Common/Useful Link references from values.yaml
+-->
+[resource-units]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+[prometheus-operator]: https://github.com/coreos/prometheus-operator
+[prom-relabel-config]: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig

--- a/charts/fronius-stack/README.gotmpl.md
+++ b/charts/fronius-stack/README.gotmpl.md
@@ -62,6 +62,32 @@ The dashboard features some panels that calculate per-day metrics.
 Make sure the Fronius Symo device, InfluxDB and Grafana dashboard are roughly in the same timezone.
 The Fronius Symo API includes counters like "energy per day" that reset at midnight.
 
+## Migrating from netdata plugin
+
+If you have used the fronius plugin that is part of netdata, you can migrate the data to the exporter variant.
+
+As this step is done manually once, it's not automated, but here's roughly how I did it:
+
+1. Install this chart but don't start the exporter and influxdb yet (0 replicas each).
+   Also disable the archival feature for now.
+2. Modify the InfluxDB 2.x StatefulSet, so that you can migrate using the Docker approach.
+   You'd need to set `DOCKER_INFLUXDB_INIT_MODE=upgrade` and add the volume from the old DB.
+   You can now scale the replicas to 1.
+3. Once the InfluxDB 2.x is running, enter its shell and create a new `fronius_archive` bucket from CLI.
+4. You should have now `netdata/autogen`, `fronius_live` and `fronius_archive` bucket.
+   The last 2 should be empty for now.
+5. Migrate & downsample the raw data from `netdata/autogen` bucket using the [scripts provided](files/influxdb/migration).
+   You might need to edit the query a bit if you are deviating from the defaults.
+   You can execute the scripts with `kubectl`, e.g.
+   ```
+   cat migration/<the-file>.flux | kubectl -n fronius exec -i fronius-influxdb-0 -- influx query -o fronius -t $INFLUX_TOKEN
+   ```
+6. Each migration script can take a few minutes.
+   Check the Grafana dashboard if the values make sense.
+7. Scale up the exporter and verify that values are stored in `fronius_live` bucket.
+8. Create the downsampling task for `fronius_archive`, check out the ConfigMap in the Helm chart that would installed on first installation.
+9. Delete the `netdata/autogen` bucket.
+
 <!---
 Common/Useful Link references from values.yaml
 -->

--- a/charts/fronius-stack/README.md
+++ b/charts/fronius-stack/README.md
@@ -74,6 +74,32 @@ The dashboard features some panels that calculate per-day metrics.
 Make sure the Fronius Symo device, InfluxDB and Grafana dashboard are roughly in the same timezone.
 The Fronius Symo API includes counters like "energy per day" that reset at midnight.
 
+## Migrating from netdata plugin
+
+If you have used the fronius plugin that is part of netdata, you can migrate the data to the exporter variant.
+
+As this step is done manually once, it's not automated, but here's roughly how I did it:
+
+1. Install this chart but don't start the exporter and influxdb yet (0 replicas each).
+   Also disable the archival feature for now.
+2. Modify the InfluxDB 2.x StatefulSet, so that you can migrate using the Docker approach.
+   You'd need to set `DOCKER_INFLUXDB_INIT_MODE=upgrade` and add the volume from the old DB.
+   You can now scale the replicas to 1.
+3. Once the InfluxDB 2.x is running, enter its shell and create a new `fronius_archive` bucket from CLI.
+4. You should have now `netdata/autogen`, `fronius_live` and `fronius_archive` bucket.
+   The last 2 should be empty for now.
+5. Migrate & downsample the raw data from `netdata/autogen` bucket using the [scripts provided](files/influxdb/migration).
+   You might need to edit the query a bit if you are deviating from the defaults.
+   You can execute the scripts with `kubectl`, e.g.
+   ```
+   cat migration/<the-file>.flux | kubectl -n fronius exec -i fronius-influxdb-0 -- influx query -o fronius -t $INFLUX_TOKEN
+   ```
+6. Each migration script can take a few minutes.
+   Check the Grafana dashboard if the values make sense.
+7. Scale up the exporter and verify that values are stored in `fronius_live` bucket.
+8. Create the downsampling task for `fronius_archive`, check out the ConfigMap in the Helm chart that would installed on first installation.
+9. Delete the `netdata/autogen` bucket.
+
 <!---
 Common/Useful Link references from values.yaml
 -->
@@ -97,6 +123,7 @@ Common/Useful Link references from values.yaml
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | archival.bucket | string | `"fronius_archive"` | Name of the archival bucket to create after installation. |
+| archival.enabled | bool | `true` | Whether long-term archival is enabled. Note: Disabling archival after installation (when enabled) does not remove the archival bucket. |
 | archival.retention | string | `"0s"` | Retention of the archival bucket. `0s` means forever. |
 | archival.window | string | `"10m"` | Fixed windows of time in which metrics are averaged. |
 | fronius.enabled | bool | `true` |  |
@@ -119,7 +146,7 @@ Common/Useful Link references from values.yaml
 | influxdb.adminUser.retention_policy | string | `"14d"` |  |
 | influxdb.enabled | bool | `true` |  |
 | influxdb.pdb.create | bool | `false` |  |
-| influxdb.persistence.size | string | `"8Gi"` |  |
+| influxdb.persistence.size | string | `"2Gi"` |  |
 | influxdb.resources.limits.memory | string | `"256Mi"` |  |
 | influxdb.resources.requests.cpu | string | `"50m"` |  |
 | influxdb.resources.requests.memory | string | `"128Mi"` |  |

--- a/charts/fronius-stack/README.md
+++ b/charts/fronius-stack/README.md
@@ -1,0 +1,126 @@
+# fronius-stack
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+A Helm chart for installing fronius-exporter with long-term storage
+
+## Installation
+
+```bash
+helm repo add ccremer https://ccremer.github.io/charts
+helm install fronius-stack ccremer/fronius-stack
+```
+> ⚠️ **WARNING**: See [data retention](#data-retention) first!
+
+## About
+
+This Helm chart installs the fronius-exporter along with long-term storage and a Grafana dashboard.
+The goal is to be able to do statistics of the photovoltaic installation.
+
+I wanted to keep fronius-exporter Helm chart minimal in case you're only interested in the exporter or you're bringing your own metrics stack.
+
+## Features
+
+* fronius-exporter chart
+* InfluxDB 2 chart
+  - Post-Install hook to configure archival bucket with downsampling
+* Grafana datasource
+* Grafana dashboard
+
+## Minimal required parameters
+
+You must configure following parameters in the minimum:
+
+```yaml
+influxdb:
+  adminUser:
+    token: changeme
+    password: changeme
+
+fronius:
+  exporter:
+    symoUrl: http://your.symo.device.or.ip/solar_api/v1/GetPowerFlowRealtimeData.fcgi
+  telegraf:
+    influxdb:
+      token: changeme # should to be the same as `influxdb.adminUser.token`!
+    globalTags:
+      site: my-home
+```
+
+## Data retention
+
+Before installing the chart, think about data retention.
+By default, the chart installs InfluxDB 2.0 with an initial bucket that keeps metrics for 14 days.
+
+Additionally, the chart features a one-time post-install hook to create an archival bucket that keeps data forever.
+It also creates a tasks that periodically downsamples the high-precision data to 10-minute-averages into the archival bucket.
+This bucket is meant to hold data for years.
+
+You can adjust retention with the following parameters:
+```console
+influxdb.adminUser.retention_policy
+archival.*
+```
+
+> ℹ️ **NOTE**: After installation, any changes in bucket namings, retention or downsampling settings will NOT be applied anymore.
+> You'd need to manually change this with InfluxDB CLI within the pod.
+
+## Grafana integration
+
+The chart comes with a Grafana datasource and dashboard ConfigMaps enabled by default.
+Please ensure Grafana sidecar is enabled and it searches in the release namespace, or set `grafana.*.namespace`.
+
+The dashboard features some panels that calculate per-day metrics.
+Make sure the Fronius Symo device, InfluxDB and Grafana dashboard are roughly in the same timezone.
+The Fronius Symo API includes counters like "energy per day" that reset at midnight.
+
+<!---
+Common/Useful Link references from values.yaml
+-->
+[resource-units]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+[prometheus-operator]: https://github.com/coreos/prometheus-operator
+[prom-relabel-config]: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+
+## Source Code
+
+* <https://github.com/ccremer/fronius-exporter>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://ccremer.github.io/charts | fronius(fronius-exporter) | 0.7.0 |
+| https://helm.influxdata.com | influxdb(influxdb2) | 2.0.1 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| archival.bucket | string | `"fronius_archive"` | Name of the archival bucket to create after installation. |
+| archival.retention | string | `"0s"` | Retention of the archival bucket. `0s` means forever. |
+| archival.window | string | `"10m"` | Fixed windows of time in which metrics are averaged. |
+| fronius.enabled | bool | `true` |  |
+| fronius.nameOverride | string | `"exporter"` |  |
+| fronius.telegraf.enabled | bool | `true` |  |
+| fronius.telegraf.globalTags.site | string | `"home"` | The name of the site or environment. |
+| fronius.telegraf.influxdb.bucket | string | `"fronius_live"` | The high-precision bucket name, needs to be equal to `influxdb.adminUser.bucket`. |
+| fronius.telegraf.influxdb.token | string | `""` | The token to connect to InfluxDB, needs to be equal to `influxdb.adminUser.token`. |
+| fronius.telegraf.influxdb.url | string | `"http://fronius-influxdb"` |  |
+| fronius.telegraf.interval | string | `"5s"` | Interval of sending metrics to InfluxDB. |
+| fullnameOverride | string | `""` |  |
+| grafana.dashboard.enabled | bool | `true` |  |
+| grafana.dashboard.labels | object | `{"grafana_dashboard":"1"}` | The labels which the sidecar is filtering for dashboards. |
+| grafana.dashboard.namespace | string | `""` | Override the namespace where the ConfigMap is installed, defaults to release namespace. |
+| grafana.datasource.enabled | bool | `true` |  |
+| grafana.datasource.labels | object | `{"grafana_datasource":"1"}` | The labels which the sidecar is filtering for data sources. |
+| grafana.datasource.namespace | string | `""` | Override the namespace where the ConfigMap is installed, defaults to release namespace. |
+| influxdb.adminUser.bucket | string | `"fronius_live"` |  |
+| influxdb.adminUser.organization | string | `"fronius"` |  |
+| influxdb.adminUser.retention_policy | string | `"14d"` |  |
+| influxdb.enabled | bool | `true` |  |
+| influxdb.pdb.create | bool | `false` |  |
+| influxdb.persistence.size | string | `"8Gi"` |  |
+| influxdb.resources.limits.memory | string | `"256Mi"` |  |
+| influxdb.resources.requests.cpu | string | `"50m"` |  |
+| influxdb.resources.requests.memory | string | `"128Mi"` |  |
+| nameOverride | string | `"fronius"` |  |

--- a/charts/fronius-stack/files/grafana/fronius-dashboard.json
+++ b/charts/fronius-stack/files/grafana/fronius-dashboard.json
@@ -16,8 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 5,
-  "iteration": 1623588976821,
+  "iteration": 1624196932981,
   "links": [],
   "panels": [
     {
@@ -49,8 +48,8 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 12,
-        "w": 12,
+        "h": 14,
+        "w": 22,
         "x": 0,
         "y": 1
       },
@@ -117,7 +116,7 @@
           "hide": false,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_power_load\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> sort(columns: [\"_time\"])\r\n  |> map(fn: (r) => ({_value:r._value * -1.0, _time:r._time,_field:\"Load\"}))",
+          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_power_load\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({_value:r._value * -1.0, _time:r._time,_field:\"Load\"}))",
           "refId": "Load",
           "resultFormat": "time_series",
           "select": [
@@ -154,7 +153,7 @@
           "hide": false,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_power_photovoltaic\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> sort(columns: [\"_time\"])\r\n  |> keep(columns: [\"_value\", \"_time\"])\r\n  |> set(key: \"_field\", value: \"Photovoltaic\")",
+          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_power_photovoltaic\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> keep(columns: [\"_value\", \"_time\"])\r\n  |> set(key: \"_field\", value: \"Photovoltaic\")",
           "refId": "Photovoltaics",
           "resultFormat": "time_series",
           "select": [
@@ -191,7 +190,7 @@
           "hide": false,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_power_grid\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> sort(columns: [\"_time\"])\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time,_field:\"Grid\"}))",
+          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_power_grid\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time,_field:\"Grid\"}))",
           "refId": "Grid",
           "resultFormat": "time_series",
           "select": [
@@ -254,6 +253,217 @@
       }
     },
     {
+      "datasource": "${datasource}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Photovoltaics"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Load"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Grid"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 2,
+        "x": 22,
+        "y": 1
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_power_load\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: 1d, fn: mean, createEmpty: false)\r\n  |> mean()\r\n  |> map(fn: (r) => ({Load: r._value * -1.0}))\r\n",
+          "refId": "Load",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_power_photovoltaic\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: 1d, fn: mean, createEmpty: false)\r\n  |> mean()\r\n  |> map(fn: (r) => ({Photovoltaics: r._value}))\r\n",
+          "refId": "Photovoltaics",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_power_grid\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: 1d, fn: mean, createEmpty: false)\r\n  |> mean()\r\n  |> map(fn: (r) => ({Grid: r._value}))\r\n",
+          "refId": "Grid",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Average per day",
+      "transformations": [],
+      "type": "stat"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -266,10 +476,10 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 12,
-        "w": 12,
-        "x": 12,
-        "y": 1
+        "h": 8,
+        "w": 22,
+        "x": 0,
+        "y": 15
       },
       "hiddenSeries": false,
       "id": 6,
@@ -322,7 +532,7 @@
           ],
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_autonomy_ratio\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> sort(columns: [\"_time\"])\r\n  |> keep(columns: [\"_value\", \"_time\"])\r\n  |> set(key: \"_field\", value: \"Autonomy\")",
+          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_autonomy_ratio\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> keep(columns: [\"_value\", \"_time\"])\r\n  |> set(key: \"_field\", value: \"Autonomy\")",
           "refId": "Autonomy",
           "resultFormat": "time_series",
           "select": [
@@ -359,7 +569,7 @@
           "hide": false,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_selfconsumption_ratio\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> sort(columns: [\"_time\"])\r\n  |> keep(columns: [\"_value\", \"_time\"])\r\n  |> set(key: \"_field\", value: \"Self-Consumption\")",
+          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_selfconsumption_ratio\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> keep(columns: [\"_value\", \"_time\"])\r\n  |> set(key: \"_field\", value: \"Self-Consumption\")",
           "refId": "Self-Consumption",
           "resultFormat": "time_series",
           "select": [
@@ -421,29 +631,15 @@
       }
     },
     {
-      "collapsed": false,
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 13
-      },
-      "id": 13,
-      "panels": [],
-      "title": "Energy per day",
-      "type": "row"
-    },
-    {
       "datasource": "${datasource}",
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "super-light-yellow",
-            "mode": "fixed"
+            "mode": "continuous-GrYlRd"
           },
+          "decimals": 1,
           "mappings": [],
-          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -453,30 +649,62 @@
               }
             ]
           },
-          "unit": "watth"
+          "unit": "percentunit"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Autonomy"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "Self-Consumption"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 14
+        "w": 2,
+        "x": 22,
+        "y": 15
       },
-      "id": 10,
+      "id": 21,
       "options": {
-        "displayMode": "gradient",
-        "orientation": "vertical",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
           ],
           "fields": "",
-          "limit": 14,
-          "values": true
+          "values": false
         },
-        "showUnfilled": true,
-        "text": {}
+        "text": {},
+        "textMode": "value_and_name"
       },
       "pluginVersion": "7.5.3",
       "targets": [
@@ -495,9 +723,151 @@
               "type": "fill"
             }
           ],
+          "hide": false,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "import \"strings\"\r\nfrom(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_energy_consumption\" and\r\n    r.site == \"${site}\" and\r\n    r.time_frame == \"day\"\r\n  )\r\n  |> drop(columns: [\"url\", \"host\", \"time_frame\"])\r\n  |> window(every: 24h)\r\n  |> max()\r\n  |> map(fn: (r) => ({_value: r._value, _time: r._time, _field: strings.substring(start: 0, end: 10, v: string(v: r._time))}))",
+          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_autonomy_ratio\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: 24h, fn: mean, createEmpty: false)\r\n  |> mean()\r\n  |> map(fn: (r) => ({Autonomy: r._value}))\r\n",
+          "refId": "Autonomy",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_selfconsumption_ratio\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: 24h, fn: mean, createEmpty: false)\r\n  |> mean()\r\n  |> map(fn: (r) => ({\"Self-Consumption\": r._value}))\r\n",
+          "refId": "Self-Consumption",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Average per day",
+      "transformations": [],
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 13,
+      "panels": [],
+      "title": "Energy per day",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 22,
+        "x": 0,
+        "y": 24
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"strings\"\r\nfrom(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_energy_consumption\" and\r\n    r.site == \"${site}\" and\r\n    r.time_frame == \"day\"\r\n  )\r\n  |> drop(columns: [\"url\", \"host\", \"time_frame\"])\r\n  |> window(every: 24h)\r\n  |> max()\r\n  |> group(columns: [\"site\"])\r\n  |> map(fn: (r) => ({_value: r._value, _time: r._time, _field: \"Energy per day\"}))",
           "refId": "Energy per day",
           "resultFormat": "time_series",
           "select": [
@@ -517,8 +887,48 @@
           "tags": []
         }
       ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
       "title": "Total Energy per day",
-      "type": "bargauge"
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:877",
+          "format": "watt",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:878",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "datasource": "${datasource}",
@@ -543,9 +953,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 3,
-        "x": 12,
-        "y": 14
+        "w": 2,
+        "x": 22,
+        "y": 24
       },
       "id": 16,
       "options": {
@@ -612,7 +1022,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 32
       },
       "id": 18,
       "panels": [],
@@ -644,10 +1054,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 6,
+        "w": 22,
         "x": 0,
-        "y": 23
+        "y": 33
       },
       "id": 11,
       "options": {
@@ -683,7 +1093,7 @@
           ],
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "import \"strings\"\r\nfrom(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_energy_consumption\" and\r\n    r.site == \"${site}\" and\r\n    r.time_frame == \"year\"\r\n  )\r\n  |> drop(columns: [\"url\", \"host\", \"time_frame\"])\r\n  |> window(every: 1y)\r\n  |> max()\r\n  |> map(fn: (r) => ({_value: r._value, _time: r._time, _field: strings.substring(start: 0, end: 4, v: string(v: r._time))}))",
+          "query": "import \"strings\"\r\nfrom(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_energy_consumption\" and\r\n    r.site == \"${site}\" and\r\n    r.time_frame == \"year\"\r\n  )\r\n  |> drop(columns: [\"url\", \"host\", \"time_frame\"])\r\n  |> window(every: 1y)\r\n  |> max()\r\n  |> group(columns: [\"site\"])\r\n  |> map(fn: (r) => ({_value: r._value, _time: r._time, year: int(v: strings.substring(start: 0, end: 4, v: string(v: r._time)))}))\r\n  |> group(columns: [\"site\"], mode: \"except\")",
           "refId": "Energy per year",
           "resultFormat": "time_series",
           "select": [
@@ -728,10 +1138,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 3,
-        "x": 12,
-        "y": 23
+        "h": 6,
+        "w": 2,
+        "x": 22,
+        "y": 33
       },
       "id": 19,
       "options": {
@@ -792,7 +1202,7 @@
       "type": "stat"
     }
   ],
-  "refresh": "5s",
+  "refresh": false,
   "schemaVersion": 27,
   "style": "dark",
   "tags": [
@@ -842,7 +1252,7 @@
       {
         "allValue": null,
         "datasource": "${datasource}",
-        "definition": "import \"influxdata/influxdb/v1\"\r\nv1.tagValues(\r\n    bucket: \"${bucket}\",\r\n    tag: \"site\",\r\n    predicate: (r) => true,\r\n    start: -1d\r\n)",
+        "definition": "import \"influxdata/influxdb/v1\"\r\nv1.tagValues(\r\n    bucket: \"${bucket}\",\r\n    tag: \"site\",\r\n    predicate: (r) => true,\r\n    start: -180d\r\n)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -851,7 +1261,7 @@
         "multi": false,
         "name": "site",
         "options": [],
-        "query": "import \"influxdata/influxdb/v1\"\r\nv1.tagValues(\r\n    bucket: \"${bucket}\",\r\n    tag: \"site\",\r\n    predicate: (r) => true,\r\n    start: -1d\r\n)",
+        "query": "import \"influxdata/influxdb/v1\"\r\nv1.tagValues(\r\n    bucket: \"${bucket}\",\r\n    tag: \"site\",\r\n    predicate: (r) => true,\r\n    start: -180d\r\n)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/charts/fronius-stack/files/grafana/fronius-dashboard.json
+++ b/charts/fronius-stack/files/grafana/fronius-dashboard.json
@@ -1,0 +1,876 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Charts displaying various metrics such as power, load, autonomy and energy",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 5,
+  "iteration": 1623588976821,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Power",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${datasource}",
+      "decimals": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Load",
+          "color": "#F2495C",
+          "fill": 0
+        },
+        {
+          "alias": "Photovoltaic",
+          "color": "#73BF69"
+        },
+        {
+          "alias": "Grid",
+          "color": "#5794F2"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_power_load\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> sort(columns: [\"_time\"])\r\n  |> map(fn: (r) => ({_value:r._value * -1.0, _time:r._time,_field:\"Load\"}))",
+          "refId": "Load",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_power_photovoltaic\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> sort(columns: [\"_time\"])\r\n  |> keep(columns: [\"_value\", \"_time\"])\r\n  |> set(key: \"_field\", value: \"Photovoltaic\")",
+          "refId": "Photovoltaics",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_power_grid\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> sort(columns: [\"_time\"])\r\n  |> map(fn: (r) => ({_value:r._value, _time:r._time,_field:\"Grid\"}))",
+          "refId": "Grid",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Power & Load",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transformations": [],
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "watt",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 6,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Self-Consumption",
+          "color": "#F2495C",
+          "fill": 0
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_autonomy_ratio\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> sort(columns: [\"_time\"])\r\n  |> keep(columns: [\"_value\", \"_time\"])\r\n  |> set(key: \"_field\", value: \"Autonomy\")",
+          "refId": "Autonomy",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_selfconsumption_ratio\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> sort(columns: [\"_time\"])\r\n  |> keep(columns: [\"_value\", \"_time\"])\r\n  |> set(key: \"_field\", value: \"Self-Consumption\")",
+          "refId": "Self-Consumption",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Autonomy",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": "1",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 13,
+      "panels": [],
+      "title": "Energy per day",
+      "type": "row"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "super-light-yellow",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "watth"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 10,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "limit": 14,
+          "values": true
+        },
+        "showUnfilled": true,
+        "text": {}
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"strings\"\r\nfrom(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_energy_consumption\" and\r\n    r.site == \"${site}\" and\r\n    r.time_frame == \"day\"\r\n  )\r\n  |> drop(columns: [\"url\", \"host\", \"time_frame\"])\r\n  |> window(every: 24h)\r\n  |> max()\r\n  |> map(fn: (r) => ({_value: r._value, _time: r._time, _field: strings.substring(start: 0, end: 10, v: string(v: r._time))}))",
+          "refId": "Energy per day",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Total Energy per day",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "watth"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 3,
+        "x": 12,
+        "y": 14
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"strings\"\r\nfrom(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_energy_consumption\" and\r\n    r.site == \"${site}\" and\r\n    r.time_frame == \"day\"\r\n  )\r\n  |> window(every: 24h)\r\n  |> max()\r\n  |> keep(columns: [\"_value\"])\r\n  |> mean()",
+          "refId": "Energy per day",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Average Energy per day",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 18,
+      "panels": [],
+      "title": "Energy per year",
+      "type": "row"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "super-light-purple",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "watth"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 11,
+      "options": {
+        "displayMode": "basic",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "limit": 10,
+          "values": true
+        },
+        "showUnfilled": true,
+        "text": {}
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"strings\"\r\nfrom(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_energy_consumption\" and\r\n    r.site == \"${site}\" and\r\n    r.time_frame == \"year\"\r\n  )\r\n  |> drop(columns: [\"url\", \"host\", \"time_frame\"])\r\n  |> window(every: 1y)\r\n  |> max()\r\n  |> map(fn: (r) => ({_value: r._value, _time: r._time, _field: strings.substring(start: 0, end: 4, v: string(v: r._time))}))",
+          "refId": "Energy per year",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Total Energy per year",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "watth"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 3,
+        "x": 12,
+        "y": 23
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "import \"strings\"\r\nfrom(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_energy_consumption\" and\r\n    r.site == \"${site}\" and\r\n    r.time_frame == \"year\"\r\n  )\r\n  |> window(every: 1y)\r\n  |> max()\r\n  |> keep(columns: [\"_value\"])\r\n  |> mean()",
+          "refId": "Energy per day",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "title": "Average Energy per year",
+      "type": "stat"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "fronius"
+  ],
+  "templating": {
+    "list": [
+      {
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "influxdb",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "datasource": "${datasource}",
+        "definition": "buckets()\r\n  |> filter(fn: (r) => r.name != \"_monitoring\" and r.name != \"_tasks\")",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Bucket",
+        "multi": false,
+        "name": "bucket",
+        "options": [],
+        "query": "buckets()\r\n  |> filter(fn: (r) => r.name != \"_monitoring\" and r.name != \"_tasks\")",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "datasource": "${datasource}",
+        "definition": "import \"influxdata/influxdb/v1\"\r\nv1.tagValues(\r\n    bucket: \"${bucket}\",\r\n    tag: \"site\",\r\n    predicate: (r) => true,\r\n    start: -1d\r\n)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Site",
+        "multi": false,
+        "name": "site",
+        "options": [],
+        "query": "import \"influxdata/influxdb/v1\"\r\nv1.tagValues(\r\n    bucket: \"${bucket}\",\r\n    tag: \"site\",\r\n    predicate: (r) => true,\r\n    start: -1d\r\n)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Fronius Symo",
+  "uid": "wTbh9P6Gk",
+  "version": 2
+}

--- a/charts/fronius-stack/files/influxdb/migration/autonomy.flux
+++ b/charts/fronius-stack/files/influxdb/migration/autonomy.flux
@@ -1,0 +1,23 @@
+import "influxdata/influxdb/v1"
+
+bucket = "netdata/autogen"
+
+multiplyByX = (x, tables=<-) =>
+  tables
+    |> map(fn: (r) => ({
+        r with
+        _value: r._value * x
+      })
+    )
+
+from(bucket: bucket)
+  |> range(start: -5y, stop: -10d)
+  |> filter(fn:(r) =>
+    r._measurement == "netdata.solar.fronius_solar.autonomy.autonomy"
+  )
+  |> map(fn: (r) => ({r with _measurement: "fronius_site_autonomy_ratio"}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> multiplyByX(x: 0.01)
+  |> set(key: "site", value: "sirius")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: "fronius_archive")

--- a/charts/fronius-stack/files/influxdb/migration/energy_day.flux
+++ b/charts/fronius-stack/files/influxdb/migration/energy_day.flux
@@ -1,0 +1,24 @@
+import "influxdata/influxdb/v1"
+
+bucket = "netdata/autogen"
+
+multiplyByX = (x, tables=<-) =>
+  tables
+    |> map(fn: (r) => ({
+        r with
+        _value: r._value * x
+      })
+    )
+
+from(bucket: bucket)
+  |> range(start: -5y, stop: -12d)
+  |> filter(fn:(r) =>
+    r._measurement == "netdata.solar.fronius_solar.energy.today.today"
+  )
+  |> map(fn: (r) => ({r with _measurement: "fronius_site_energy_consumption"}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> multiplyByX(x: 1000.0)
+  |> set(key: "site", value: "sirius")
+  |> set(key: "time_frame", value: "day")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: "fronius_archive")

--- a/charts/fronius-stack/files/influxdb/migration/energy_year.flux
+++ b/charts/fronius-stack/files/influxdb/migration/energy_year.flux
@@ -1,0 +1,24 @@
+import "influxdata/influxdb/v1"
+
+bucket = "netdata/autogen"
+
+multiplyByX = (x, tables=<-) =>
+  tables
+    |> map(fn: (r) => ({
+        r with
+        _value: r._value * x
+      })
+    )
+
+from(bucket: bucket)
+  |> range(start: -5y, stop: -12d)
+  |> filter(fn:(r) =>
+    r._measurement == "netdata.solar.fronius_solar.energy.year.year"
+  )
+  |> map(fn: (r) => ({r with _measurement: "fronius_site_energy_consumption"}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> multiplyByX(x: 1000.0)
+  |> set(key: "site", value: "sirius")
+  |> set(key: "time_frame", value: "year")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: "fronius_archive")

--- a/charts/fronius-stack/files/influxdb/migration/inverter.flux
+++ b/charts/fronius-stack/files/influxdb/migration/inverter.flux
@@ -1,0 +1,15 @@
+import "influxdata/influxdb/v1"
+
+bucket = "netdata/autogen"
+
+from(bucket: bucket)
+  |> range(start: -4y, stop: -10d)
+  |> filter(fn:(r) =>
+    r._measurement == "netdata.solar.fronius_solar.inverters.output.inverter_1"
+  )
+  |> map(fn: (r) => ({r with _measurement: "fronius_inverter_power"}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: "sirius")
+  |> set(key: "_field", value: "gauge")
+  |> set(key: "inverter", value: "1")
+  |> to(bucket: "fronius_archive")

--- a/charts/fronius-stack/files/influxdb/migration/power_grid.flux
+++ b/charts/fronius-stack/files/influxdb/migration/power_grid.flux
@@ -1,0 +1,14 @@
+import "influxdata/influxdb/v1"
+
+bucket = "netdata/autogen"
+
+from(bucket: bucket)
+  |> range(start: -5y, stop: -10d)
+  |> filter(fn:(r) =>
+    r._measurement == "netdata.solar.fronius_solar.power.grid"
+  )
+  |> map(fn: (r) => ({r with _measurement: "fronius_site_power_grid"}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: "sirius")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: "fronius_archive")

--- a/charts/fronius-stack/files/influxdb/migration/power_load.flux
+++ b/charts/fronius-stack/files/influxdb/migration/power_load.flux
@@ -1,0 +1,23 @@
+import "influxdata/influxdb/v1"
+
+bucket = "netdata/autogen"
+
+multiplyByX = (x, tables=<-) =>
+  tables
+    |> map(fn: (r) => ({
+        r with
+        _value: r._value * x
+      })
+    )
+
+from(bucket: bucket)
+  |> range(start: -5y, stop: -10d)
+  |> filter(fn:(r) =>
+    r._measurement == "netdata.solar.fronius_solar.consumption.load"
+  )
+  |> multiplyByX(x: -1.0)
+  |> map(fn: (r) => ({r with _measurement: "fronius_site_power_load"}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: "sirius")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: "fronius_archive")

--- a/charts/fronius-stack/files/influxdb/migration/power_photo.flux
+++ b/charts/fronius-stack/files/influxdb/migration/power_photo.flux
@@ -1,0 +1,14 @@
+import "influxdata/influxdb/v1"
+
+bucket = "netdata/autogen"
+
+from(bucket: bucket)
+  |> range(start: -5y, stop: -10d)
+  |> filter(fn:(r) =>
+    r._measurement == "netdata.solar.fronius_solar.power.photovoltaics"
+  )
+  |> map(fn: (r) => ({r with _measurement: "fronius_site_power_photovoltaic"}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: "sirius")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: "fronius_archive")

--- a/charts/fronius-stack/files/influxdb/migration/selfconsumption.flux
+++ b/charts/fronius-stack/files/influxdb/migration/selfconsumption.flux
@@ -1,0 +1,23 @@
+import "influxdata/influxdb/v1"
+
+bucket = "netdata/autogen"
+
+multiplyByX = (x, tables=<-) =>
+  tables
+    |> map(fn: (r) => ({
+        r with
+        _value: r._value * x
+      })
+    )
+
+from(bucket: bucket)
+  |> range(start: -5y, stop: -10d)
+  |> filter(fn:(r) =>
+    r._measurement == "netdata.solar.fronius_solar.autonomy.self_consumption"
+  )
+  |> map(fn: (r) => ({r with _measurement: "fronius_site_selfconsumption_ratio"}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> multiplyByX(x: 0.01)
+  |> set(key: "site", value: "sirius")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: "fronius_archive")

--- a/charts/fronius-stack/files/influxdb/task.sh
+++ b/charts/fronius-stack/files/influxdb/task.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo "creating bucket ${INFLUX_BUCKET_NAME}"
+response=$(influx bucket create -r ${INFLUX_BUCKET_RETENTION})
+exit_code=$?
+echo "$response"
+if [[ "$response" != *"already exists"* && $exit_code -gt 0 ]]; then
+  exit $exit_code
+fi
+
+echo "listing existing tasks"
+response=$(influx task list)
+if [[ "$response" == *"Downsampling Fronius"* ]]; then
+  echo "task exists already, nothing to do"
+  exit 0
+fi
+
+echo "creating task"
+influx task create -f /config/task.flux

--- a/charts/fronius-stack/templates/_helpers.tpl
+++ b/charts/fronius-stack/templates/_helpers.tpl
@@ -1,0 +1,91 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fronius-stack.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fronius-stack.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fronius-stack.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "fronius-stack.labels" -}}
+helm.sh/chart: {{ include "fronius-stack.chart" . }}
+{{ include "fronius-stack.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "fronius-stack.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fronius-stack.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "fronius-stack.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "fronius-stack.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the full service name
+*/}}
+{{- define "fronius-stack.tld" -}}
+{{ .Release.Namespace }}
+{{- end }}
+{{- define "fronius-stack.influxdb-host" -}}
+http://{{ template "influxdb.fullname" . }}-influxdb.{{ .Release.Namespace }}:{{ .Values.influxdb.service.port | default 80 }}
+{{- end }}
+
+{{/*
+Helper to define env vars for influxdb jobs
+*/}}
+{{- define "fronius-stack.influxdb-env" -}}
+- name: INFLUX_HOST
+  value: {{ template "fronius-stack.influxdb-host" . }}
+- name: INFLUX_ORG
+  value: {{ .Values.influxdb.adminUser.organization }}
+- name: INFLUX_TOKEN
+  valueFrom:
+    secretKeyRef:
+      {{- if .Values.influxdb.adminUser.existingSecret }}
+      name: {{ .Values.influxdb.adminUser.existingSecret -}}
+      {{ else }}
+      name: {{ template "fronius-stack.fullname" . }}-influxdb-auth
+      {{- end }}
+      key: admin-token
+{{- end }}

--- a/charts/fronius-stack/templates/grafana/cm-dashboard.yaml
+++ b/charts/fronius-stack/templates/grafana/cm-dashboard.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.grafana.dashboard.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fronius-stack.fullname" . }}-dashboard
+  namespace: {{ default .Release.Namespace .Values.grafana.dashboard.namespace }}
+  labels:
+    {{- include "fronius-stack.labels" . | nindent 4 }}
+    {{- toYaml .Values.grafana.dashboard.labels | nindent 4}}
+  {{- if .Values.grafana.dashboard.annotations }}
+  annotations:
+    {{- toYaml .Values.grafana.dashboard.annotations | nindent 4 }}
+  {{- end }}
+data:
+  {{ (.Files.Glob "files/grafana/*.json").AsConfig | nindent 2 }}
+{{- end -}}

--- a/charts/fronius-stack/templates/grafana/secret-datasource.yaml
+++ b/charts/fronius-stack/templates/grafana/secret-datasource.yaml
@@ -15,7 +15,7 @@ stringData:
   {{ template "fronius-stack.fullname" . }}.yaml: |-
     apiVersion: 1
     datasources:
-    - name: Fronius-Influxdb
+    - name: {{ template "fronius-stack.fullname" . }}
       type: influxdb
       url: {{ include "fronius-stack.influxdb-host" . }}
       isDefault: false

--- a/charts/fronius-stack/templates/grafana/secret-datasource.yaml
+++ b/charts/fronius-stack/templates/grafana/secret-datasource.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.grafana.datasource.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fronius-stack.fullname" . }}-datasource
+  namespace: {{ default .Release.Namespace .Values.grafana.datasource.namespace }}
+  labels:
+    {{- include "fronius-stack.labels" . | nindent 4 }}
+    {{- toYaml .Values.grafana.datasource.labels | nindent 4}}
+  {{- if .Values.grafana.datasource.annotations }}
+  annotations:
+    {{- toYaml .Values.grafana.datasource.annotations | nindent 4 }}
+  {{- end }}
+stringData:
+  {{ template "fronius-stack.fullname" . }}.yaml: |-
+    apiVersion: 1
+    datasources:
+    - name: Fronius-Influxdb
+      type: influxdb
+      url: {{ include "fronius-stack.influxdb-host" . }}
+      isDefault: false
+      secureJsonData:
+        token: {{ .Values.fronius.telegraf.influxdb.token }}
+      jsonData:
+        httpMode: POST
+        timeInterval: {{ .Values.fronius.telegraf.interval }}
+        version: Flux
+        defaultBucket: {{ .Values.fronius.telegraf.influxdb.bucket }}
+        organization: {{ .Values.fronius.telegraf.influxdb.organization }}
+{{- end -}}

--- a/charts/fronius-stack/templates/influxdb/cm-influxdb-task.yaml
+++ b/charts/fronius-stack/templates/influxdb/cm-influxdb-task.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.influxdb.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fronius-stack.fullname" . }}-influxdb-task
+  labels:
+    {{- include "fronius-stack.labels" . | nindent 4 }}
+data:
+  task.flux: |
+    import "strings"
+
+    option task = {name: "Downsampling Fronius", every: {{ .Values.archival.window }}}
+
+    fromBucket = {{ .Values.influxdb.adminUser.bucket | quote }}
+    targetBucket = {{ .Values.archival.bucket | quote }}
+
+    from(bucket: fromBucket)
+      |> range(start: -task.every)
+      |> filter(fn: (r) => r._measurement =~ /^fronius_.+$/)
+      |> drop(columns: ["url", "host"])
+      |> aggregateWindow(every: task.every, fn: mean, createEmpty: false)
+      |> to(bucket: targetBucket)
+{{ (.Files.Glob "files/influxdb/*.sh").AsConfig | indent 2 }}
+{{- end -}}

--- a/charts/fronius-stack/templates/influxdb/cm-influxdb-task.yaml
+++ b/charts/fronius-stack/templates/influxdb/cm-influxdb-task.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.influxdb.enabled }}
+{{- if and .Values.influxdb.enabled .Values.archival.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/fronius-stack/templates/influxdb/job-influxdb-task.yaml
+++ b/charts/fronius-stack/templates/influxdb/job-influxdb-task.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "fronius-stack.fullname" . }}-influxdb-task
+  labels:
+    {{- include "fronius-stack.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "fronius-stack.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      initContainers:
+        - name: wait-for-influx
+          image: "{{ .Values.influxdb.image.repository }}:{{ .Values.influxdb.image.tag }}"
+          command: ["/bin/sh"]
+          args:
+            - -c
+            - until influx bucket list; do sleep 2; done
+          env:
+            {{ include "fronius-stack.influxdb-env" . | nindent 12 }}
+      containers:
+        - name: post-install-job
+          image: "{{ .Values.influxdb.image.repository }}:{{ .Values.influxdb.image.tag }}"
+          command: ["/bin/sh"]
+          args:
+            - /config/task.sh
+          env:
+            {{ include "fronius-stack.influxdb-env" . | nindent 12 }}
+            - name: INFLUX_BUCKET_NAME
+              value: {{ .Values.archival.bucket }}
+            - name: INFLUX_BUCKET_RETENTION
+              value: {{ .Values.archival.retention }}
+          volumeMounts:
+            - name: scripts
+              mountPath: /config
+      volumes:
+        - name: scripts
+          configMap:
+            name: {{ template "fronius-stack.fullname" . }}-influxdb-task

--- a/charts/fronius-stack/templates/influxdb/job-influxdb-task.yaml
+++ b/charts/fronius-stack/templates/influxdb/job-influxdb-task.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.influxdb.enabled .Values.archival.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -42,3 +43,4 @@ spec:
         - name: scripts
           configMap:
             name: {{ template "fronius-stack.fullname" . }}-influxdb-task
+{{- end -}}

--- a/charts/fronius-stack/values.yaml
+++ b/charts/fronius-stack/values.yaml
@@ -42,3 +42,13 @@ archival:
   window: 10m
   bucket: fronius_archive
   retention: 0s
+
+grafana:
+  datasource:
+    enabled: true
+    labels:
+      grafana_datasource: "1"
+  dashboard:
+    enabled: true
+    labels:
+      grafana_dashboard: "1"

--- a/charts/fronius-stack/values.yaml
+++ b/charts/fronius-stack/values.yaml
@@ -20,7 +20,7 @@ influxdb:
     retention_policy: 14d
 
   persistence:
-    size: 8Gi
+    size: 2Gi
 
   pdb:
     create: false
@@ -43,6 +43,8 @@ fronius:
       site: home
 
 archival:
+  # -- Whether long-term archival is enabled. Note: Disabling archival after installation (when enabled) does not remove the archival bucket.
+  enabled: true
   # -- Fixed windows of time in which metrics are averaged.
   window: 10m
   # -- Name of the archival bucket to create after installation.

--- a/charts/fronius-stack/values.yaml
+++ b/charts/fronius-stack/values.yaml
@@ -30,25 +30,38 @@ fronius:
   nameOverride: exporter
   telegraf:
     enabled: true
+    # -- Interval of sending metrics to InfluxDB.
     interval: 5s
     influxdb:
       url: http://fronius-influxdb
+      # -- The token to connect to InfluxDB, needs to be equal to `influxdb.adminUser.token`.
       token: ""
+      # -- The high-precision bucket name, needs to be equal to `influxdb.adminUser.bucket`.
       bucket: fronius_live
     globalTags:
+      # -- The name of the site or environment.
       site: home
 
 archival:
+  # -- Fixed windows of time in which metrics are averaged.
   window: 10m
+  # -- Name of the archival bucket to create after installation.
   bucket: fronius_archive
+  # -- Retention of the archival bucket. `0s` means forever.
   retention: 0s
 
 grafana:
   datasource:
     enabled: true
+    # -- Override the namespace where the ConfigMap is installed, defaults to release namespace.
+    namespace: ""
+    # -- The labels which the sidecar is filtering for data sources.
     labels:
       grafana_datasource: "1"
   dashboard:
     enabled: true
+    # -- Override the namespace where the ConfigMap is installed, defaults to release namespace.
+    namespace: ""
+    # -- The labels which the sidecar is filtering for dashboards.
     labels:
       grafana_dashboard: "1"

--- a/charts/fronius-stack/values.yaml
+++ b/charts/fronius-stack/values.yaml
@@ -1,0 +1,44 @@
+# Default values for fronius-stack.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+nameOverride: fronius
+fullnameOverride: ""
+
+influxdb:
+  enabled: true
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+
+  adminUser:
+    organization: fronius
+    bucket: fronius_live
+    retention_policy: 14d
+
+  persistence:
+    size: 8Gi
+
+  pdb:
+    create: false
+
+fronius:
+  enabled: true
+  nameOverride: exporter
+  telegraf:
+    enabled: true
+    interval: 5s
+    influxdb:
+      url: http://fronius-influxdb
+      token: ""
+      bucket: fronius_live
+    globalTags:
+      site: home
+
+archival:
+  window: 10m
+  bucket: fronius_archive
+  retention: 0s


### PR DESCRIPTION
#### What this PR does / why we need it:

Installs and configures following charts:

* Fronius exporter with Telegraf sidecar
* InfluxDB v2.x

Extra features:
* Grafana datasource & dashboard (best integrated with Prometheus Operator resp. kube-prometheus-stack)
* Downsampling & archival bucket in InfluxDB

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make docs lint` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
