### PR TITLE
Add prepare target for charts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,8 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
+      - name: Prepare charts
+        run: make prepare
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,5 +25,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: Prepare charts
+        run: make prepare
       - name: Run Chart unit tests
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -55,3 +55,10 @@ lint\:versions: ## Checks if chart versions have been changed
 	@changed_charts=$$(git diff --dirstat=files,0 origin/master..HEAD -- charts | cut -d '/' -f 2 | uniq) ; \
 	  echo "Charts changed: $$changed_charts" ; echo ;  \
 	  for dir in $$changed_charts; do git diff origin/master..HEAD -- "charts/$${dir}/Chart.yaml" | grep -H --label=$${dir} "+version"; done
+
+.PHONY: prepare
+prepare: ## Prepare the charts for testing
+	@echo --- Preparing charts
+	@find charts -type f -name Makefile | sed 's|/[^/]*$$||' | xargs -I '%' make -C '%' prepare
+	@echo 'Check for uncommitted changes ...'
+	git diff --exit-code

--- a/charts/clustercode/Chart.yaml
+++ b/charts/clustercode/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/clustercode/Makefile
+++ b/charts/clustercode/Makefile
@@ -38,3 +38,8 @@ update: rbac appVersion ## Updates all templates
 .PHONY: help
 help: ## Show this help
 	@grep -E -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+#
+# "Interface" for parent Makefile
+#
+prepare: ## Prepare helm chart

--- a/charts/clustercode/README.md
+++ b/charts/clustercode/README.md
@@ -1,6 +1,6 @@
 # clustercode
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.0.0-rc2](https://img.shields.io/badge/AppVersion-v2.0.0--rc2-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.0.0-rc2](https://img.shields.io/badge/AppVersion-v2.0.0--rc2-informational?style=flat-square)
 
 Movie and Series conversion Operator
 

--- a/charts/fronius-stack/Makefile
+++ b/charts/fronius-stack/Makefile
@@ -1,0 +1,8 @@
+
+#
+# "Interface" for parent Makefile
+#
+prepare: ## Prepare helm chart
+	helm repo add ccremer https://ccremer.github.io/charts
+	helm repo add influx https://helm.influxdata.com
+	helm dep build


### PR DESCRIPTION


#### What this PR does / why we need it:

* Some charts require dependencies which are needed before releasing them.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make docs lint` passes
