### PR TITLE
 [fronius-stack] Dashboard: fix energy per day time axis

### DIFF
--- a/charts/fronius-stack/Chart.lock
+++ b/charts/fronius-stack/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: fronius-exporter
   repository: https://ccremer.github.io/charts
-  version: 0.7.0
+  version: 0.7.1
 - name: influxdb2
   repository: https://helm.influxdata.com
   version: 2.0.1
-digest: sha256:6e7967a5a8c8c1fc96bc87f8dd095d6b4b84a74397eb521ce2b38a1d0f71e0c7
-generated: "2021-06-13T15:07:45.092638342+02:00"
+digest: sha256:e1480889fe1121a70eb08848528ef5d6f5483ac83621b4dd7ce0c9b5b12a5765
+generated: "2021-06-26T18:59:27.280280214+02:00"

--- a/charts/fronius-stack/Chart.yaml
+++ b/charts/fronius-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -28,7 +28,7 @@ sources:
 
 dependencies:
   - name: fronius-exporter
-    version: 0.7.0
+    version: 0.7.1
     repository: https://ccremer.github.io/charts
     alias: fronius
     condition: fronius.enabled

--- a/charts/fronius-stack/Makefile
+++ b/charts/fronius-stack/Makefile
@@ -1,8 +1,13 @@
 
+repo: ## Initialize depedant repositories
+	helm repo add ccremer https://ccremer.github.io/charts
+	helm repo add influx https://helm.influxdata.com
+
+update: repo ## Update helm dependencies
+	helm dep update
+
 #
 # "Interface" for parent Makefile
 #
-prepare: ## Prepare helm chart
-	helm repo add ccremer https://ccremer.github.io/charts
-	helm repo add influx https://helm.influxdata.com
+prepare: repo ## Prepare helm chart
 	helm dep build

--- a/charts/fronius-stack/README.md
+++ b/charts/fronius-stack/README.md
@@ -1,6 +1,6 @@
 # fronius-stack
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for installing fronius-exporter with long-term storage
 
@@ -115,7 +115,7 @@ Common/Useful Link references from values.yaml
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://ccremer.github.io/charts | fronius(fronius-exporter) | 0.7.0 |
+| https://ccremer.github.io/charts | fronius(fronius-exporter) | 0.7.1 |
 | https://helm.influxdata.com | influxdb(influxdb2) | 2.0.1 |
 
 ## Values

--- a/charts/fronius-stack/files/grafana/fronius-dashboard.json
+++ b/charts/fronius-stack/files/grafana/fronius-dashboard.json
@@ -16,7 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1624196932981,
+  "iteration": 1624718409543,
   "links": [],
   "panels": [
     {
@@ -867,7 +867,7 @@
           ],
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "import \"strings\"\r\nfrom(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_energy_consumption\" and\r\n    r.site == \"${site}\" and\r\n    r.time_frame == \"day\"\r\n  )\r\n  |> drop(columns: [\"url\", \"host\", \"time_frame\"])\r\n  |> window(every: 24h)\r\n  |> max()\r\n  |> group(columns: [\"site\"])\r\n  |> map(fn: (r) => ({_value: r._value, _time: r._time, _field: \"Energy per day\"}))",
+          "query": "import \"strings\"\r\nimport \"date\"\r\nfrom(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"fronius_site_energy_consumption\" and\r\n    r.site == \"${site}\" and\r\n    r.time_frame == \"day\"\r\n  )\r\n  |> drop(columns: [\"url\", \"host\", \"time_frame\"])\r\n  |> window(every: 24h)\r\n  |> max()\r\n  |> group(columns: [\"site\"])\r\n  |> map(fn: (r) => ({_value: r._value, _time: date.truncate(t: r._time, unit: 1d), _field: \"Energy per day\"}))",
           "refId": "Energy per day",
           "resultFormat": "time_series",
           "select": [
@@ -1282,5 +1282,5 @@
   "timezone": "",
   "title": "Fronius Symo",
   "uid": "wTbh9P6Gk",
-  "version": 2
+  "version": 4
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

* Adjusts the query so that the bars in the time axis of the "Energy per Day" panel starts at the beginning of the day, not where the max value is.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make docs lint` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
