### PR TITLE
[fronius-exporter] Upgrade fronius-exporter to v0.8.0

### DIFF
--- a/charts/fronius-exporter/Chart.yaml
+++ b/charts/fronius-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.1
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fronius-exporter/README.md
+++ b/charts/fronius-exporter/README.md
@@ -1,6 +1,6 @@
 # fronius-exporter
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Prometheus Exporter for Fronius Symo Photovoltaics
 
@@ -43,14 +43,16 @@ Common/Useful Link references from values.yaml
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | exporter.additionalArgs | list | `[]` | Provide additional CLI flags via string array |
-| exporter.symoUrl | string | `"http://symo.ip.or.hostname/solar_api/v1/GetPowerFlowRealtimeData.fcgi"` | Target URL of Fronius SYMO device. **Required** |
+| exporter.endpoints.archive | bool | `true` | Whether archive data scraping is enabled. Note that this request can take a few seconds. |
+| exporter.endpoints.powerFlow | bool | `true` | Whether power flow data scraping is enabled. |
+| exporter.symoUrl | string | `"http://symo.ip.or.hostname"` | Target URL of Fronius SYMO device. **Required** |
 | exporter.timeoutSeconds | int | `5` | Time after which collecting may time out. Should not be higher than the Prometheus scrape interval. |
 | fullnameOverride | string | `""` |  |
 | hostAliases | object | `{}` | A dict with `{ip, hostnames array}` to configure custom entries in /etc/hosts. See [values.yaml](./values.yaml) for an example. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"quay.io"` | Container image registry |
 | image.repository | string | `"ccremer/fronius-exporter"` | Location of the container image |
-| image.tag | string | `"v0.6.1"` | Container image tag |
+| image.tag | string | `"v0.8.0"` | Container image tag |
 | imagePullSecrets | list | `[]` | List of image pull secrets if you use a privately hosted image |
 | ingress.annotations | object | `{}` | Additional annotations for the Ingress object |
 | ingress.enabled | bool | `false` | Useful if your Prometheus is outside of the cluster |

--- a/charts/fronius-exporter/templates/deployment.yaml
+++ b/charts/fronius-exporter/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
           args:
             - --symo.url={{ .Values.exporter.symoUrl }}
             - --symo.timeout={{ .Values.exporter.timeoutSeconds }}
+            - --symo.enable-power-flow={{ .Values.exporter.endpoints.powerFlow }}
+            - --symo.enable-archive={{ .Values.exporter.endpoints.archive }}
             {{- range .Values.exporter.additionalArgs }}
             - {{ . }}
             {{- end }}

--- a/charts/fronius-exporter/values.yaml
+++ b/charts/fronius-exporter/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- Location of the container image
   repository: ccremer/fronius-exporter
   # -- Container image tag
-  tag: v0.6.1
+  tag: v0.8.0
   pullPolicy: IfNotPresent
 
 # -- List of image pull secrets if you use a privately hosted image
@@ -21,12 +21,18 @@ fullnameOverride: ""
 
 exporter:
   # -- Target URL of Fronius SYMO device. **Required**
-  symoUrl: "http://symo.ip.or.hostname/solar_api/v1/GetPowerFlowRealtimeData.fcgi"
+  symoUrl: "http://symo.ip.or.hostname"
   # -- Provide additional CLI flags via string array
   additionalArgs: []
   # -- Time after which collecting may time out. Should not be higher than
   # the Prometheus scrape interval.
   timeoutSeconds: 5
+  endpoints:
+    # -- Whether power flow data scraping is enabled.
+    powerFlow: true
+    # -- Whether archive data scraping is enabled.
+    # Note that this request can take a few seconds.
+    archive: true
 
 telegraf:
   # -- Whether to enable Telegraf sidecar for Influxdb


### PR DESCRIPTION
#### What this PR does / why we need it:

* Updates image tag to v0.8.0
* Due to braking changes in v0.8.0, the URL in `exporter.symoUrl` should now be only the root URL of the device (e.g. `http://ip.or.hostname`)
* Adds `exporter.endpoints.powerFlow=true`
* Adds `exporter.endpoints.archive=true`

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make docs lint` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
