### PR TITLE
[fronius-stack] Update fronius-exporter chart to v0.8.0

### DIFF
--- a/charts/fronius-stack/Chart.lock
+++ b/charts/fronius-stack/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: fronius-exporter
   repository: https://ccremer.github.io/charts
-  version: 0.7.1
+  version: 0.8.0
 - name: influxdb2
   repository: https://helm.influxdata.com
   version: 2.0.1
-digest: sha256:e1480889fe1121a70eb08848528ef5d6f5483ac83621b4dd7ce0c9b5b12a5765
-generated: "2021-06-26T18:59:27.280280214+02:00"
+digest: sha256:b64dbb9c97ad992dd54959dcf0e92da0b3f507e6ece3567c6be6b11b10d3e89e
+generated: "2021-08-13T01:01:36.524491539+02:00"

--- a/charts/fronius-stack/Chart.yaml
+++ b/charts/fronius-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -28,7 +28,7 @@ sources:
 
 dependencies:
   - name: fronius-exporter
-    version: 0.7.1
+    version: 0.8.0
     repository: https://ccremer.github.io/charts
     alias: fronius
     condition: fronius.enabled

--- a/charts/fronius-stack/README.md
+++ b/charts/fronius-stack/README.md
@@ -1,6 +1,6 @@
 # fronius-stack
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for installing fronius-exporter with long-term storage
 
@@ -115,7 +115,7 @@ Common/Useful Link references from values.yaml
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://ccremer.github.io/charts | fronius(fronius-exporter) | 0.7.1 |
+| https://ccremer.github.io/charts | fronius(fronius-exporter) | 0.8.0 |
 | https://helm.influxdata.com | influxdb(influxdb2) | 2.0.1 |
 
 ## Values


### PR DESCRIPTION
#### What this PR does / why we need it:

* Updates fronius-exporter chart to v0.8.0.

See #88 

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make docs lint` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
