### PR TITLE
Generate a changelog after helm-chart-releaser published release

### DIFF
--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -1,0 +1,57 @@
+{
+  "pr_template": "- ${{TITLE}} (#${{NUMBER}})",
+  "categories": [
+    {
+      "title": "## 🚀 Features",
+      "labels": [
+        "enhancement",
+        "feature"
+      ]
+    },
+    {
+      "title": "## 🛠️ Minor Changes",
+      "labels": [
+        "change"
+      ]
+    },
+    {
+      "title": "## 🔎 Breaking Changes",
+      "labels": [
+        "breaking"
+      ]
+    },
+    {
+      "title": "## 🐛 Fixes",
+      "labels": [
+        "bug",
+        "fix"
+      ]
+    },
+    {
+      "title": "## 📄 Documentation",
+      "labels": [
+        "documentation"
+      ]
+    },
+    {
+      "title": "## 🔗 Dependency Updates",
+      "labels": [
+        "dependency"
+      ]
+    }
+  ],
+  "template": "${{CATEGORIZED_COUNT}} changes since ${{FROM_TAG}}\n\n${{CHANGELOG}}",
+  "label_extractor": [
+    {
+      "pattern": "<from-workflow>",
+      "method": "replace",
+      "target": "ignore",
+      "on_property": "title"
+    }
+  ],
+  "tag_resolver": {
+    "filter": {
+      "pattern": "<from-workflow>"
+    }
+  }
+}

--- a/.github/changelog.sh
+++ b/.github/changelog.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Remove "refs/tags/"
+tag="${GITHUB_REF##*/}"
+
+# Remove SemVer at the end
+chart=$(echo ${tag} | grep -P -o '^([a-zA-Z0-9-]+)(?![0-9.]+)')
+
+tagPattern="${chart}-(.+)"
+labelPattern='^(?!\\['${chart}'\\])'
+
+echo "Tag search pattern: $tagPattern"
+echo "Label search pattern: $labelPattern"
+
+cat .github/changelog-configuration.json | jq '.tag_resolver.filter.pattern="'$tagPattern'" | .label_extractor[0].pattern="'$labelPattern'"' > .github/configuration.json
+# cat .github/configuration.json

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,36 @@
+name: Changelog
+
+on:
+  release:
+    types:
+    - created
+
+jobs:
+  edit-release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Prepare changelog config
+      run: .github/changelog.sh
+
+    - name: Build changelog from PRs with labels
+      id: build_changelog
+      uses: mikepenz/release-changelog-builder-action@v2
+      with:
+        configuration: ".github/configuration.json"
+        # PreReleases still get a changelog, but the next full release gets a diff since the last full release,
+        # combining possible changelogs of all previous PreReleases in between.
+        # PreReleases show a partial changelog since last PreRelease.
+        ignorePreReleases: "${{ !contains(github.ref, '-rc') }}"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Update release
+      uses: tubone24/update_release@v1.2.0
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        body: ${{ steps.build_changelog.outputs.changelog }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /**/*/.vscode
 *.log
 /charts/*/charts
+
+.github/configuration.json


### PR DESCRIPTION
#### What this PR does / why we need it:

* Add a changelog generator

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [ ] Chart Version bumped
- [ ] `make docs lint` passes
- [ ] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [ ] Title of the PR contains starts with chart name e.g. `[chart]`
