### PR TITLE
Add stiebeleltron-exporter chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 | [![chart downloads](https://img.shields.io/github/downloads/ccremer/charts/fronius-stack-0.1.4/total)](https://github.com/ccremer/charts/releases/tag/fronius-stack-0.1.4) | [fronius-stack](charts/fronius-stack/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/ccremer/charts/kubernetes-zfs-provisioner-1.1.2/total)](https://github.com/ccremer/charts/releases/tag/kubernetes-zfs-provisioner-1.1.2) | [kubernetes-zfs-provisioner](charts/kubernetes-zfs-provisioner/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/ccremer/charts/samba-0.1.1/total)](https://github.com/ccremer/charts/releases/tag/samba-0.1.1) | [samba](charts/samba/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/ccremer/charts/stiebeleltron-exporter-0.1.0/total)](https://github.com/ccremer/charts/releases/tag/stiebeleltron-exporter-0.1.0) | [stiebeleltron-exporter](charts/stiebeleltron-exporter/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/ccremer/charts/znapzend-0.5.4/total)](https://github.com/ccremer/charts/releases/tag/znapzend-0.5.4) | [znapzend](charts/znapzend/README.md) |
 
 ## Development

--- a/charts/stiebeleltron-exporter/.helmignore
+++ b/charts/stiebeleltron-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/stiebeleltron-exporter/Chart.yaml
+++ b/charts/stiebeleltron-exporter/Chart.yaml
@@ -1,0 +1,35 @@
+apiVersion: v2
+name: stiebeleltron-exporter
+description: Prometheus Exporter for Stiebel Eltron heat pump ISG
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+#appVersion: "1.16.0"
+
+keywords:
+  - stiebel eltron
+  - isg
+  - heat pump
+  - exporter
+  - prometheus
+icon: https://www.stiebel-eltron.com/apps/ste/docroot/images/single/logo-stiebel-eltron-red-black.svg
+home: https://github.com/ccremer/stiebeleltron-exporter
+sources:
+  - https://github.com/ccremer/stiebeleltron-exporter

--- a/charts/stiebeleltron-exporter/README.gotmpl.md
+++ b/charts/stiebeleltron-exporter/README.gotmpl.md
@@ -1,0 +1,20 @@
+
+## Prometheus Operator
+
+This chart features templates for [Prometheus Operator][prometheus-operator] if desired.
+If you'd like to add additional Prometheus labels to all metrics, you could make use of relabelings:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  metricRelabelings:
+    - targetLabel: site
+      replacement: my-home
+```
+
+<!---
+Common/Useful Link references from values.yaml
+-->
+[resource-units]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+[prometheus-operator]: https://github.com/coreos/prometheus-operator
+[prom-relabel-config]: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig

--- a/charts/stiebeleltron-exporter/README.md
+++ b/charts/stiebeleltron-exporter/README.md
@@ -1,0 +1,89 @@
+# stiebeleltron-exporter
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+Prometheus Exporter for Stiebel Eltron heat pump ISG
+
+**Homepage:** <https://github.com/ccremer/stiebeleltron-exporter>
+
+## Installation
+
+```bash
+helm repo add ccremer https://ccremer.github.io/charts
+helm install stiebeleltron-exporter ccremer/stiebeleltron-exporter
+```
+
+## Prometheus Operator
+
+This chart features templates for [Prometheus Operator][prometheus-operator] if desired.
+If you'd like to add additional Prometheus labels to all metrics, you could make use of relabelings:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  metricRelabelings:
+    - targetLabel: site
+      replacement: my-home
+```
+
+<!---
+Common/Useful Link references from values.yaml
+-->
+[resource-units]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+[prometheus-operator]: https://github.com/coreos/prometheus-operator
+[prom-relabel-config]: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+
+## Source Code
+
+* <https://github.com/ccremer/stiebeleltron-exporter>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| exporter.additionalArgs | list | `[]` | Provide additional CLI flags via string array |
+| exporter.isgUrl | string | `"http://isg.ip.or.hostname"` | Target URL of Stiebel Eltron ISG device. **Required** |
+| exporter.timeoutSeconds | int | `5` | Time after which collecting may time out. Should not be higher than the Prometheus scrape interval. |
+| fullnameOverride | string | `""` |  |
+| hostAliases | object | `{}` | A dict with `{ip, hostnames array}` to configure custom entries in /etc/hosts. See [values.yaml](./values.yaml) for an example. |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.registry | string | `"ghcr.io"` | Container image registry |
+| image.repository | string | `"ccremer/stiebeleltron-exporter"` | Location of the container image |
+| image.tag | string | `"v0.1.0"` | Container image tag |
+| imagePullSecrets | list | `[]` | List of image pull secrets if you use a privately hosted image |
+| ingress.annotations | object | `{}` | Additional annotations for the Ingress object |
+| ingress.enabled | bool | `false` | Useful if your Prometheus is outside of the cluster |
+| ingress.hosts | list | `[]` | See Kubernetes Docs for a guide to setup Ingress hosts |
+| ingress.tls | list | `[]` | See Kubernetes Docs for a guide to setup TLS on Ingress |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| replicaCount | int | `1` | Usually `1` is fine |
+| resources.limits.memory | string | `"64Mi"` |  |
+| resources.requests.cpu | string | `"20m"` |  |
+| resources.requests.memory | string | `"32Mi"` |  |
+| securityContext | object | `{}` |  |
+| service.nodePort | int | `0` | Node port number if `type` is `NodePort` |
+| service.port | int | `8080` | Service port number |
+| service.type | string | `"ClusterIP"` | Service type |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and `create` is `true`, a name is generated using the fullname template |
+| serviceMonitor.additionalLabels | object | `{}` | Add custom labels to the ServiceMonitor object |
+| serviceMonitor.enabled | bool | `false` | Deploy a ServiceMonitor object for Prometheus. Requires an installed [Prometheus Operator][prometheus-operator]. |
+| serviceMonitor.metricRelabelings | list | `[]` | Add relabeling configs before ingestion, see [RelabelConfig][prom-relabel-config]. |
+| serviceMonitor.namespace | string | `""` | Namespace in which to deploy the ServiceMonitor, defaults to release namespace. |
+| serviceMonitor.scrapeInterval | string | `""` | Override default scrape interval from Prometheus |
+| telegraf.enabled | bool | `false` | Whether to enable Telegraf sidecar for Influxdb |
+| telegraf.globalTags | object | `{}` | A dict with `key: value` to add to `global_tags` config |
+| telegraf.image.registry | string | `"docker.io"` |  |
+| telegraf.image.repository | string | `"library/telegraf"` | Telegraf image location |
+| telegraf.image.tag | string | `"1.20-alpine"` | Telegraf image tag |
+| telegraf.influxdb.bucket | string | `"stiebeleltron"` | Bucket to write metrics into |
+| telegraf.influxdb.organization | string | `"stiebeleltron"` | Organization where the bucket belongs to |
+| telegraf.influxdb.token | string | `""` | Token used to authenticate to InfluxDB |
+| telegraf.influxdb.url | string | `"http://influxdb2"` | URL of an InfluxDB 2 instance |
+| telegraf.interval | string | `"30s"` | Go-style interval in which metrics are pushed to InfluxDB |
+| tolerations | list | `[]` |  |

--- a/charts/stiebeleltron-exporter/templates/NOTES.txt
+++ b/charts/stiebeleltron-exporter/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "stiebeleltron-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "stiebeleltron-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "stiebeleltron-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "stiebeleltron-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/stiebeleltron-exporter/templates/_helpers.tpl
+++ b/charts/stiebeleltron-exporter/templates/_helpers.tpl
@@ -1,0 +1,72 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "stiebeleltron-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "stiebeleltron-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "stiebeleltron-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "stiebeleltron-exporter.labels" -}}
+helm.sh/chart: {{ include "stiebeleltron-exporter.chart" . }}
+{{ include "stiebeleltron-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "stiebeleltron-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "stiebeleltron-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "stiebeleltron-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "stiebeleltron-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Container images
+*/}}
+{{- define "stiebeleltron-exporter.image" -}}
+{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+{{- end }}
+{{- define "stiebeleltron-exporter.telegrafImage" -}}
+{{ .Values.telegraf.image.registry }}/{{ .Values.telegraf.image.repository }}:{{ .Values.telegraf.image.tag }}
+{{- end }}

--- a/charts/stiebeleltron-exporter/templates/deployment.yaml
+++ b/charts/stiebeleltron-exporter/templates/deployment.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stiebeleltron-exporter.fullname" . }}
+  labels:
+    {{- include "stiebeleltron-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "stiebeleltron-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- if or .Values.telegraf.enabled .Values.podAnnotations }}
+      annotations:
+        {{- if .Values.telegraf.enabled }}
+        app.kubernetes.io/checksum: telegraf={{ include (print $.Template.BasePath "/telegraf-secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      labels:
+        {{- include "stiebeleltron-exporter.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "stiebeleltron-exporter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: exporter
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "stiebeleltron-exporter.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --isg.url={{ .Values.exporter.isgUrl }}
+            - --isg.timeout={{ .Values.exporter.timeoutSeconds }}
+            {{- range .Values.exporter.additionalArgs }}
+            - {{ . }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.telegraf.enabled }}
+        - name: telegraf
+          image: {{ include "stiebeleltron-exporter.telegrafImage" . }}
+          resources:
+            limits:
+              cpu: 200m
+              memory: 200Mi
+            requests:
+              cpu: 10m
+              memory: 10Mi
+          volumeMounts:
+            - name: telegraf-config
+              mountPath: /etc/telegraf
+      volumes:
+        - name: telegraf-config
+          secret:
+            secretName: {{ template "stiebeleltron-exporter.fullname" . }}
+            defaultMode: 420
+      {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+      {{- range $ip, $hostnames := . }}
+        - ip: {{ $ip }}
+          hostnames:
+          {{- range . }}
+            - {{ . }}
+          {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/stiebeleltron-exporter/templates/ingress.yaml
+++ b/charts/stiebeleltron-exporter/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "stiebeleltron-exporter.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "stiebeleltron-exporter.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/stiebeleltron-exporter/templates/prometheus/service-monitor.yaml
+++ b/charts/stiebeleltron-exporter/templates/prometheus/service-monitor.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "stiebeleltron-exporter.fullname" . }}-servicemonitor
+  namespace: {{ default .Release.Namespace .Values.serviceMonitor.namespace }}
+  labels:
+    {{- include "stiebeleltron-exporter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- if .Values.serviceMonitor.annotations }}
+  annotations:
+{{ toYaml .Values.serviceMonitor.annotations | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "stiebeleltron-exporter.selectorLabels" . | nindent 6 }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  {{- end }}
+  endpoints:
+    - path: /metrics
+      port: http
+      interval: {{ .Values.serviceMonitor.scrapeInterval }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end -}}

--- a/charts/stiebeleltron-exporter/templates/service.yaml
+++ b/charts/stiebeleltron-exporter/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stiebeleltron-exporter.fullname" . }}
+  labels:
+    {{- include "stiebeleltron-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- if eq .Values.service.type "NodePort" }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "stiebeleltron-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/stiebeleltron-exporter/templates/serviceaccount.yaml
+++ b/charts/stiebeleltron-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "stiebeleltron-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "stiebeleltron-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/stiebeleltron-exporter/templates/telegraf-secret.yaml
+++ b/charts/stiebeleltron-exporter/templates/telegraf-secret.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.telegraf.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "stiebeleltron-exporter.fullname" . }}
+  labels:
+    {{- include "stiebeleltron-exporter.labels" . | nindent 4 }}
+stringData:
+  telegraf.conf: |
+    [[inputs.prometheus]]
+      urls = ["http://localhost:8080/metrics"]
+      interval = {{ .Values.telegraf.interval | quote }}
+    [[outputs.influxdb_v2]]
+      urls = [{{ .Values.telegraf.influxdb.url | quote }}]
+      token = {{ .Values.telegraf.influxdb.token | quote }}
+      organization = {{ .Values.telegraf.influxdb.organization | quote }}
+      bucket = {{ .Values.telegraf.influxdb.bucket | quote }}
+    {{- with .Values.telegraf.globalTags }}
+    [global_tags]
+    {{- range $key,$value := . }}
+      {{ $key }} = {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+{{- end -}}

--- a/charts/stiebeleltron-exporter/values.yaml
+++ b/charts/stiebeleltron-exporter/values.yaml
@@ -1,0 +1,128 @@
+# Default values for stiebeleltron-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Usually `1` is fine
+replicaCount: 1
+
+image:
+  # -- Container image registry
+  registry: ghcr.io
+  # -- Location of the container image
+  repository: ccremer/stiebeleltron-exporter
+  # -- Container image tag
+  tag: v0.1.0
+  pullPolicy: IfNotPresent
+
+# -- List of image pull secrets if you use a privately hosted image
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+exporter:
+  # -- Target URL of Stiebel Eltron ISG device. **Required**
+  isgUrl: "http://isg.ip.or.hostname"
+  # -- Provide additional CLI flags via string array
+  additionalArgs: []
+  # -- Time after which collecting may time out. Should not be higher than
+  # the Prometheus scrape interval.
+  timeoutSeconds: 5
+
+telegraf:
+  # -- Whether to enable Telegraf sidecar for Influxdb
+  enabled: false
+  # -- Go-style interval in which metrics are pushed to InfluxDB
+  interval: 30s
+  image:
+    registry: docker.io
+    # -- Telegraf image location
+    repository: library/telegraf
+    # -- Telegraf image tag
+    tag: 1.20-alpine
+  influxdb:
+    # -- URL of an InfluxDB 2 instance
+    url: http://influxdb2
+    # -- Token used to authenticate to InfluxDB
+    token: ""
+    # -- Bucket to write metrics into
+    bucket: stiebeleltron
+    # -- Organization where the bucket belongs to
+    organization: stiebeleltron
+  # -- A dict with `key: value` to add to `global_tags` config
+  globalTags: {}
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and `create` is `true`, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+# -- A dict with `{ip, hostnames array}` to configure custom entries in /etc/hosts.
+# See [values.yaml](./values.yaml) for an example.
+hostAliases: {}
+#  192.168.1.1:
+#    - my-custom-host.name
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Service port number
+  port: 8080
+  # -- Node port number if `type` is `NodePort`
+  nodePort: 0
+
+ingress:
+  # -- Useful if your Prometheus is outside of the cluster
+  enabled: false
+  # -- Additional annotations for the Ingress object
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+
+  # -- See Kubernetes Docs for a guide to setup Ingress hosts
+  hosts: []
+  # -- See Kubernetes Docs for a guide to setup TLS on Ingress
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  limits:
+    memory: 64Mi
+  requests:
+    cpu: 20m
+    memory: 32Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+serviceMonitor:
+  # -- Deploy a ServiceMonitor object for Prometheus. Requires an installed [Prometheus Operator][prometheus-operator].
+  enabled: false
+  # -- Namespace in which to deploy the ServiceMonitor, defaults to release namespace.
+  namespace: ""
+  # -- Override default scrape interval from Prometheus
+  scrapeInterval: ""
+  # -- Add relabeling configs before ingestion, see [RelabelConfig][prom-relabel-config].
+  metricRelabelings: []
+  # -- Add custom labels to the ServiceMonitor object
+  additionalLabels: {}


### PR DESCRIPTION
#### What this PR does / why we need it:

* Add chart for https://github.com/ccremer/stiebeleltron-exporter

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make docs lint` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/[chart]`
- [x] PR contains the label that identifies the type of change, which is one of
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
