### PR TITLE
Add stiebeleltron-stack chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 | [![chart downloads](https://img.shields.io/github/downloads/ccremer/charts/kubernetes-zfs-provisioner-1.1.2/total)](https://github.com/ccremer/charts/releases/tag/kubernetes-zfs-provisioner-1.1.2) | [kubernetes-zfs-provisioner](charts/kubernetes-zfs-provisioner/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/ccremer/charts/samba-0.1.1/total)](https://github.com/ccremer/charts/releases/tag/samba-0.1.1) | [samba](charts/samba/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/ccremer/charts/stiebeleltron-exporter-0.1.1/total)](https://github.com/ccremer/charts/releases/tag/stiebeleltron-exporter-0.1.1) | [stiebeleltron-exporter](charts/stiebeleltron-exporter/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/ccremer/charts/stiebeleltron-stack-0.1.0/total)](https://github.com/ccremer/charts/releases/tag/stiebeleltron-stack-0.1.0) | [stiebeleltron-stack](charts/stiebeleltron-stack/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/ccremer/charts/znapzend-0.5.4/total)](https://github.com/ccremer/charts/releases/tag/znapzend-0.5.4) | [znapzend](charts/znapzend/README.md) |
 
 ## Development

--- a/charts/stiebeleltron-stack/.helmignore
+++ b/charts/stiebeleltron-stack/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/stiebeleltron-stack/Chart.lock
+++ b/charts/stiebeleltron-stack/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: stiebeleltron-exporter
+  repository: https://ccremer.github.io/charts
+  version: 0.1.0
+- name: influxdb2
+  repository: https://helm.influxdata.com
+  version: 2.0.4
+digest: sha256:46ad65dd0a4eca266c542dc6ccf4c9f3f7f73c34cb6d85e2888b9dbbf4500c4b
+generated: "2021-12-12T16:23:18.747836615+01:00"

--- a/charts/stiebeleltron-stack/Chart.yaml
+++ b/charts/stiebeleltron-stack/Chart.yaml
@@ -1,0 +1,39 @@
+apiVersion: v2
+name: stiebeleltron-stack
+description: A Helm chart for installing stiebeleltron-exporter with long-term storage
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+#appVersion: "1.16.0"
+
+sources:
+  - https://github.com/ccremer/stiebeleltron-exporter
+
+dependencies:
+  - name: stiebeleltron-exporter
+    version: 0.1.0
+    repository: https://ccremer.github.io/charts
+    alias: stiebeleltron
+    condition: stiebeleltron.enabled
+  - name: influxdb2
+    alias: influxdb
+    version: 2.0.4
+    repository: https://helm.influxdata.com
+    condition: influxdb.enabled

--- a/charts/stiebeleltron-stack/Chart.yaml
+++ b/charts/stiebeleltron-stack/Chart.yaml
@@ -28,7 +28,7 @@ sources:
 
 dependencies:
   - name: stiebeleltron-exporter
-    version: 0.1.0
+    version: 0.1.1
     repository: https://ccremer.github.io/charts
     alias: stiebeleltron
     condition: stiebeleltron.enabled

--- a/charts/stiebeleltron-stack/README.gotmpl.md
+++ b/charts/stiebeleltron-stack/README.gotmpl.md
@@ -1,0 +1,96 @@
+> ⚠️ **WARNING**: See [data retention](#data-retention) first!
+
+## About
+
+This Helm chart installs the stiebeleltron-exporter along with long-term storage and a Grafana dashboard.
+The goal is to be able to do statistics of the photovoltaic installation.
+
+I wanted to keep stiebeleltron-exporter Helm chart minimal in case you're only interested in the exporter or you're bringing your own metrics stack.
+
+## Features
+
+* stiebeleltron-exporter chart
+* InfluxDB 2 chart
+  - Post-Install hook to configure archival bucket with downsampling
+* Grafana datasource
+* Grafana dashboard
+
+## Minimal required parameters
+
+You must configure following parameters in the minimum:
+
+```yaml
+influxdb:
+  adminUser:
+    token: changeme
+    password: changeme
+
+stiebeleltron:
+  exporter:
+    isgUrl: http://your.isg.device.or.ip/
+  telegraf:
+    influxdb:
+      token: changeme # should be the same as `influxdb.adminUser.token`!
+    globalTags:
+      site: my-home
+```
+
+## Data retention
+
+Before installing the chart, think about data retention.
+By default, the chart installs InfluxDB 2.0 with an initial bucket that keeps metrics for 14 days.
+
+Additionally, the chart features a one-time post-install hook to create an archival bucket that keeps data forever.
+It also creates a tasks that periodically downsamples the high-precision data to 10-minute-averages into the archival bucket.
+This bucket is meant to hold data for years.
+
+You can adjust retention with the following parameters:
+```console
+influxdb.adminUser.retention_policy
+archival.*
+```
+
+> ℹ️ **NOTE**: After installation, any changes in bucket namings, retention or downsampling settings will NOT be applied anymore.
+> You'd need to manually change this with InfluxDB CLI within the pod.
+
+## Grafana integration
+
+The chart comes with a Grafana datasource and dashboard ConfigMaps enabled by default.
+Please ensure Grafana sidecar is enabled and it searches in the release namespace, or set `grafana.*.namespace`.
+
+The dashboard features some panels that calculate per-day metrics.
+Make sure the stiebeleltron ISG device, InfluxDB and Grafana dashboard are roughly in the same timezone.
+The stiebeleltron ISG console includes counters like "energy per day" that reset at midnight.
+
+## Migrating from netdata plugin
+
+If you have used the stiebeleltron plugin that is part of netdata, you can migrate the data to the exporter variant.
+
+As this step is done manually once, it's not automated, but here's roughly how I did it:
+
+1. Install this chart but don't start the exporter and influxdb yet (0 replicas each).
+   Also disable the archival feature for now.
+2. Modify the InfluxDB 2.x StatefulSet, so that you can migrate using the Docker approach.
+   You'd need to set `DOCKER_INFLUXDB_INIT_MODE=upgrade` and add the volume from the old DB.
+   You can now scale the replicas to 1.
+3. Once the InfluxDB 2.x is running, enter its shell and create a new `stiebeleltron_archive` bucket from CLI.
+4. You should have now `netdata/autogen`, `stiebeleltron_live` and `stiebeleltron_archive` bucket.
+   The last 2 should be empty for now.
+5. Migrate & downsample the raw data from `netdata/autogen` bucket using the [scripts provided](files/influxdb/migration).
+   You might need to edit the query a bit if you are deviating from the defaults.
+   You can execute the scripts with `kubectl`, e.g.
+   ```
+   cat migration/<the-file>.flux | kubectl -n stiebeleltron exec -i stiebeleltron-influxdb-0 -- influx query -o stiebeleltron -t $INFLUX_TOKEN
+   ```
+6. Each migration script can take a few minutes.
+   Check the Grafana dashboard if the values make sense.
+7. Scale up the exporter and verify that values are stored in `stiebeleltron_live` bucket.
+8. Create the downsampling task for `stiebeleltron_archive`, check out the ConfigMap in the Helm chart that would installed on first installation.
+9. Delete the `netdata/autogen` bucket.
+
+<!---
+Common/Useful Link references from values.yaml
+-->
+[resource-units]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+[prometheus-operator]: https://github.com/coreos/prometheus-operator
+[prom-relabel-config]: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig

--- a/charts/stiebeleltron-stack/README.md
+++ b/charts/stiebeleltron-stack/README.md
@@ -83,22 +83,36 @@ As this step is done manually once, it's not automated, but here's roughly how I
 1. Install this chart but don't start the exporter and influxdb yet (0 replicas each).
    Also disable the archival feature for now.
 2. Modify the InfluxDB 2.x StatefulSet, so that you can migrate using the Docker approach.
-   You'd need to set `DOCKER_INFLUXDB_INIT_MODE=upgrade` and add the volume from the old DB.
-   You can now scale the replicas to 1.
-3. Once the InfluxDB 2.x is running, enter its shell and create a new `stiebeleltron_archive` bucket from CLI.
-4. You should have now `netdata/autogen`, `stiebeleltron_live` and `stiebeleltron_archive` bucket.
+   You'd need to set `DOCKER_INFLUXDB_INIT_MODE=upgrade` and add the volume mounts from the old DB.
+   Set `INFLUXD_ENGINE_PATH=/var/lib/influxdb2/migration` (we appended `migration`, otherwise there will be some permission errors).
+   Set `INFLUXD_BOLT_PATH=/var/lib/influxdb2/migration/influxd.bolt`.
+3. You can now scale the replicas to 1.
+4. Once the InfluxDB 2.x is running and the old DB upgraded, enter its shell and execute the following:
+   ```
+   influx backup /var/lib/influxdb2/backup
+   ```
+5. Exit shell and scale replica to 0.
+6. Reset `DOCKER_INFLUXDB_INIT_MODE`, `INFLUXD_ENGINE_PATH` and `INFLUXD_BOLT_PATH` to default values and set `replicas=1`.
+7. Enter shell again and execute a restore:
+   ```
+   influx bucket delete --name stiebeleltron_live
+   influx restore /var/lib/influxdb2/backup
+   influx bucket create --name stiebeleltron_archive --org stiebeleltron
+   rm -rf /var/lib/influxdb2/migration /var/lib/influxdb2/backup
+   ```
+8. You should have now `netdata/autogen`, `stiebeleltron_live` and `stiebeleltron_archive` bucket.
    The last 2 should be empty for now.
-5. Migrate & downsample the raw data from `netdata/autogen` bucket using the [scripts provided](files/influxdb/migration).
+9. Migrate & downsample the raw data from `netdata/autogen` bucket using the [scripts provided](files/influxdb/migration).
    You might need to edit the query a bit if you are deviating from the defaults.
    You can execute the scripts with `kubectl`, e.g.
    ```
-   cat migration/<the-file>.flux | kubectl -n stiebeleltron exec -i stiebeleltron-influxdb-0 -- influx query -o stiebeleltron -t $INFLUX_TOKEN
+   cat migration/<the-file>.flux | kubectl -n stiebeleltron exec -i stiebeleltron-influxdb-0 -- influx query -o stiebeleltron
    ```
-6. Each migration script can take a few minutes.
+10. Each migration script can take a few minutes.
    Check the Grafana dashboard if the values make sense.
-7. Scale up the exporter and verify that values are stored in `stiebeleltron_live` bucket.
-8. Create the downsampling task for `stiebeleltron_archive`, check out the ConfigMap in the Helm chart that would installed on first installation.
-9. Delete the `netdata/autogen` bucket.
+11. Scale up the exporter and verify that values are stored in `stiebeleltron_live` bucket.
+12. Create the downsampling task for `stiebeleltron_archive`, check out the ConfigMap in the Helm chart that would installed on first installation.
+13. Delete the `netdata/autogen` bucket via CLI.
 
 <!---
 Common/Useful Link references from values.yaml
@@ -116,7 +130,7 @@ Common/Useful Link references from values.yaml
 | Repository | Name | Version |
 |------------|------|---------|
 | https://ccremer.github.io/charts | stiebeleltron(stiebeleltron-exporter) | 0.1.0 |
-| https://helm.influxdata.com | influxdb(influxdb2) | 2.0.5 |
+| https://helm.influxdata.com | influxdb(influxdb2) | 2.0.4 |
 
 ## Values
 

--- a/charts/stiebeleltron-stack/README.md
+++ b/charts/stiebeleltron-stack/README.md
@@ -1,0 +1,153 @@
+# stiebeleltron-stack
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+A Helm chart for installing stiebeleltron-exporter with long-term storage
+
+## Installation
+
+```bash
+helm repo add ccremer https://ccremer.github.io/charts
+helm install stiebeleltron-stack ccremer/stiebeleltron-stack
+```
+> ⚠️ **WARNING**: See [data retention](#data-retention) first!
+
+## About
+
+This Helm chart installs the stiebeleltron-exporter along with long-term storage and a Grafana dashboard.
+The goal is to be able to do statistics of the photovoltaic installation.
+
+I wanted to keep stiebeleltron-exporter Helm chart minimal in case you're only interested in the exporter or you're bringing your own metrics stack.
+
+## Features
+
+* stiebeleltron-exporter chart
+* InfluxDB 2 chart
+  - Post-Install hook to configure archival bucket with downsampling
+* Grafana datasource
+* Grafana dashboard
+
+## Minimal required parameters
+
+You must configure following parameters in the minimum:
+
+```yaml
+influxdb:
+  adminUser:
+    token: changeme
+    password: changeme
+
+stiebeleltron:
+  exporter:
+    isgUrl: http://your.isg.device.or.ip/
+  telegraf:
+    influxdb:
+      token: changeme # should be the same as `influxdb.adminUser.token`!
+    globalTags:
+      site: my-home
+```
+
+## Data retention
+
+Before installing the chart, think about data retention.
+By default, the chart installs InfluxDB 2.0 with an initial bucket that keeps metrics for 14 days.
+
+Additionally, the chart features a one-time post-install hook to create an archival bucket that keeps data forever.
+It also creates a tasks that periodically downsamples the high-precision data to 10-minute-averages into the archival bucket.
+This bucket is meant to hold data for years.
+
+You can adjust retention with the following parameters:
+```console
+influxdb.adminUser.retention_policy
+archival.*
+```
+
+> ℹ️ **NOTE**: After installation, any changes in bucket namings, retention or downsampling settings will NOT be applied anymore.
+> You'd need to manually change this with InfluxDB CLI within the pod.
+
+## Grafana integration
+
+The chart comes with a Grafana datasource and dashboard ConfigMaps enabled by default.
+Please ensure Grafana sidecar is enabled and it searches in the release namespace, or set `grafana.*.namespace`.
+
+The dashboard features some panels that calculate per-day metrics.
+Make sure the stiebeleltron ISG device, InfluxDB and Grafana dashboard are roughly in the same timezone.
+The stiebeleltron ISG console includes counters like "energy per day" that reset at midnight.
+
+## Migrating from netdata plugin
+
+If you have used the stiebeleltron plugin that is part of netdata, you can migrate the data to the exporter variant.
+
+As this step is done manually once, it's not automated, but here's roughly how I did it:
+
+1. Install this chart but don't start the exporter and influxdb yet (0 replicas each).
+   Also disable the archival feature for now.
+2. Modify the InfluxDB 2.x StatefulSet, so that you can migrate using the Docker approach.
+   You'd need to set `DOCKER_INFLUXDB_INIT_MODE=upgrade` and add the volume from the old DB.
+   You can now scale the replicas to 1.
+3. Once the InfluxDB 2.x is running, enter its shell and create a new `stiebeleltron_archive` bucket from CLI.
+4. You should have now `netdata/autogen`, `stiebeleltron_live` and `stiebeleltron_archive` bucket.
+   The last 2 should be empty for now.
+5. Migrate & downsample the raw data from `netdata/autogen` bucket using the [scripts provided](files/influxdb/migration).
+   You might need to edit the query a bit if you are deviating from the defaults.
+   You can execute the scripts with `kubectl`, e.g.
+   ```
+   cat migration/<the-file>.flux | kubectl -n stiebeleltron exec -i stiebeleltron-influxdb-0 -- influx query -o stiebeleltron -t $INFLUX_TOKEN
+   ```
+6. Each migration script can take a few minutes.
+   Check the Grafana dashboard if the values make sense.
+7. Scale up the exporter and verify that values are stored in `stiebeleltron_live` bucket.
+8. Create the downsampling task for `stiebeleltron_archive`, check out the ConfigMap in the Helm chart that would installed on first installation.
+9. Delete the `netdata/autogen` bucket.
+
+<!---
+Common/Useful Link references from values.yaml
+-->
+[resource-units]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+[prometheus-operator]: https://github.com/coreos/prometheus-operator
+[prom-relabel-config]: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+
+## Source Code
+
+* <https://github.com/ccremer/stiebeleltron-exporter>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://ccremer.github.io/charts | stiebeleltron(stiebeleltron-exporter) | 0.1.0 |
+| https://helm.influxdata.com | influxdb(influxdb2) | 2.0.5 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| archival.bucket | string | `"stiebeleltron_archive"` | Name of the archival bucket to create after installation. |
+| archival.enabled | bool | `true` | Whether long-term archival is enabled. Note: Disabling archival after installation (when enabled) does not remove the archival bucket. |
+| archival.retention | string | `"0s"` | Retention of the archival bucket. `0s` means forever. |
+| archival.window | string | `"10m"` | Fixed windows of time in which metrics are averaged. |
+| fullnameOverride | string | `""` |  |
+| grafana.dashboard.enabled | bool | `true` |  |
+| grafana.dashboard.labels | object | `{"grafana_dashboard":"1"}` | The labels which the sidecar is filtering for dashboards. |
+| grafana.dashboard.namespace | string | `""` | Override the namespace where the ConfigMap is installed, defaults to release namespace. |
+| grafana.datasource.enabled | bool | `true` |  |
+| grafana.datasource.labels | object | `{"grafana_datasource":"1"}` | The labels which the sidecar is filtering for data sources. |
+| grafana.datasource.namespace | string | `""` | Override the namespace where the ConfigMap is installed, defaults to release namespace. |
+| influxdb.adminUser.bucket | string | `"stiebeleltron_live"` |  |
+| influxdb.adminUser.organization | string | `"stiebeleltron"` |  |
+| influxdb.adminUser.retention_policy | string | `"14d"` |  |
+| influxdb.enabled | bool | `true` |  |
+| influxdb.pdb.create | bool | `false` |  |
+| influxdb.persistence.size | string | `"2Gi"` |  |
+| influxdb.resources.limits.memory | string | `"256Mi"` |  |
+| influxdb.resources.requests.cpu | string | `"50m"` |  |
+| influxdb.resources.requests.memory | string | `"128Mi"` |  |
+| nameOverride | string | `"stiebeleltron"` |  |
+| stiebeleltron.enabled | bool | `true` |  |
+| stiebeleltron.nameOverride | string | `"exporter"` |  |
+| stiebeleltron.telegraf.enabled | bool | `true` |  |
+| stiebeleltron.telegraf.globalTags.site | string | `"home"` | The name of the site or environment. |
+| stiebeleltron.telegraf.influxdb.bucket | string | `"stiebeleltron_live"` | The high-precision bucket name, needs to be equal to `influxdb.adminUser.bucket`. |
+| stiebeleltron.telegraf.influxdb.token | string | `""` | The token to connect to InfluxDB, needs to be equal to `influxdb.adminUser.token`. |
+| stiebeleltron.telegraf.influxdb.url | string | `"http://stiebeleltron-influxdb"` |  |
+| stiebeleltron.telegraf.interval | string | `"5s"` | Interval of sending metrics to InfluxDB. |

--- a/charts/stiebeleltron-stack/README.md
+++ b/charts/stiebeleltron-stack/README.md
@@ -129,7 +129,7 @@ Common/Useful Link references from values.yaml
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://ccremer.github.io/charts | stiebeleltron(stiebeleltron-exporter) | 0.1.0 |
+| https://ccremer.github.io/charts | stiebeleltron(stiebeleltron-exporter) | 0.1.1 |
 | https://helm.influxdata.com | influxdb(influxdb2) | 2.0.4 |
 
 ## Values

--- a/charts/stiebeleltron-stack/files/grafana/stiebeleltron-dashboard.js
+++ b/charts/stiebeleltron-stack/files/grafana/stiebeleltron-dashboard.js
@@ -1,0 +1,1538 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_STIEBELELTRON",
+      "label": "stiebeleltron",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    }
+  ],
+    "__requires": [
+      {
+        "type": "grafana",
+        "id": "grafana",
+        "name": "Grafana",
+        "version": "8.2.3"
+      },
+      {
+        "type": "datasource",
+        "id": "influxdb",
+        "name": "InfluxDB",
+        "version": "1.0.0"
+      },
+      {
+        "type": "panel",
+        "id": "stat",
+        "name": "Stat",
+        "version": ""
+      },
+      {
+        "type": "panel",
+        "id": "timeseries",
+        "name": "Time series",
+        "version": ""
+      }
+    ],
+      "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Charts displaying various metrics such as power, load, autonomy and energy",
+    "editable": true,
+      "fiscalYearStartMonth": 0,
+        "gnetId": null,
+          "graphTooltip": 0,
+            "id": null,
+              "iteration": 1641139741081,
+                "links": [],
+                  "liveNow": false,
+                    "panels": [
+                      {
+                        "collapsed": false,
+                        "datasource": null,
+                        "gridPos": {
+                          "h": 1,
+                          "w": 24,
+                          "x": 0,
+                          "y": 0
+                        },
+                        "id": 25,
+                        "panels": [],
+                        "title": "Temperatures",
+                        "type": "row"
+                      },
+                      {
+                        "datasource": "${DS_STIEBELELTRON}",
+                        "description": "",
+                        "fieldConfig": {
+                          "defaults": {
+                            "color": {
+                              "mode": "palette-classic"
+                            },
+                            "custom": {
+                              "axisLabel": "",
+                              "axisPlacement": "auto",
+                              "barAlignment": 0,
+                              "drawStyle": "line",
+                              "fillOpacity": 0,
+                              "gradientMode": "none",
+                              "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                              },
+                              "lineInterpolation": "linear",
+                              "lineStyle": {
+                                "fill": "solid"
+                              },
+                              "lineWidth": 1,
+                              "pointSize": 5,
+                              "scaleDistribution": {
+                                "type": "linear"
+                              },
+                              "showPoints": "auto",
+                              "spanNulls": false,
+                              "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                              },
+                              "thresholdsStyle": {
+                                "mode": "off"
+                              }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                              "mode": "absolute",
+                              "steps": [
+                                {
+                                  "color": "green",
+                                  "value": null
+                                },
+                                {
+                                  "color": "red",
+                                  "value": 80
+                                }
+                              ]
+                            },
+                            "unit": "celsius"
+                          },
+                          "overrides": []
+                        },
+                        "gridPos": {
+                          "h": 8,
+                          "w": 12,
+                          "x": 0,
+                          "y": 1
+                        },
+                        "id": 23,
+                        "options": {
+                          "legend": {
+                            "calcs": [
+                              "mean"
+                            ],
+                            "displayMode": "list",
+                            "placement": "bottom"
+                          },
+                          "tooltip": {
+                            "mode": "single"
+                          }
+                        },
+                        "targets": [
+                          {
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_room_temperature_heating_circuit\" and\r\n    r.site == \"${site}\" and\r\n    r.circuit == \"hc1\" and\r\n    r.state == \"actual\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Actual\":r._value, _time:r._time}))\r\n",
+                            "refId": "room temperature actual"
+                          },
+                          {
+                            "hide": false,
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_room_temperature_heating_circuit\" and\r\n    r.site == \"${site}\" and\r\n    r.circuit == \"hc1\" and\r\n    r.state == \"target\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Target\":r._value, _time:r._time}))\r\n",
+                            "refId": "room temperature target"
+                          }
+                        ],
+                        "title": "Room Temperature HC 1",
+                        "type": "timeseries"
+                      },
+                      {
+                        "datasource": "${DS_STIEBELELTRON}",
+                        "description": "",
+                        "fieldConfig": {
+                          "defaults": {
+                            "color": {
+                              "mode": "palette-classic"
+                            },
+                            "custom": {
+                              "axisLabel": "",
+                              "axisPlacement": "auto",
+                              "barAlignment": 0,
+                              "drawStyle": "line",
+                              "fillOpacity": 0,
+                              "gradientMode": "none",
+                              "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                              },
+                              "lineInterpolation": "linear",
+                              "lineStyle": {
+                                "fill": "solid"
+                              },
+                              "lineWidth": 1,
+                              "pointSize": 5,
+                              "scaleDistribution": {
+                                "type": "linear"
+                              },
+                              "showPoints": "auto",
+                              "spanNulls": false,
+                              "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                              },
+                              "thresholdsStyle": {
+                                "mode": "off"
+                              }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                              "mode": "absolute",
+                              "steps": [
+                                {
+                                  "color": "green",
+                                  "value": null
+                                },
+                                {
+                                  "color": "red",
+                                  "value": 80
+                                }
+                              ]
+                            },
+                            "unit": "celsius"
+                          },
+                          "overrides": []
+                        },
+                        "gridPos": {
+                          "h": 8,
+                          "w": 12,
+                          "x": 12,
+                          "y": 1
+                        },
+                        "id": 26,
+                        "options": {
+                          "legend": {
+                            "calcs": [
+                              "mean"
+                            ],
+                            "displayMode": "list",
+                            "placement": "bottom"
+                          },
+                          "tooltip": {
+                            "mode": "single"
+                          }
+                        },
+                        "targets": [
+                          {
+                            "hide": false,
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_room_temperature_heating_circuit\" and\r\n    r.site == \"${site}\" and\r\n    r.circuit == \"hc2\" and\r\n    r.state == \"actual\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Actual\":r._value, _time:r._time}))\r\n",
+                            "refId": "HC 2, Actual"
+                          },
+                          {
+                            "hide": false,
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_room_temperature_heating_circuit\" and\r\n    r.site == \"${site}\" and\r\n    r.circuit == \"hc2\" and\r\n    r.state == \"target\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Target\":r._value, _time:r._time}))\r\n",
+                            "refId": "HC 2, Target"
+                          }
+                        ],
+                        "title": "Room Temperature HC 2",
+                        "type": "timeseries"
+                      },
+                      {
+                        "datasource": "${DS_STIEBELELTRON}",
+                        "fieldConfig": {
+                          "defaults": {
+                            "color": {
+                              "mode": "palette-classic"
+                            },
+                            "custom": {
+                              "axisLabel": "",
+                              "axisPlacement": "auto",
+                              "barAlignment": 0,
+                              "drawStyle": "line",
+                              "fillOpacity": 0,
+                              "gradientMode": "none",
+                              "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                              },
+                              "lineInterpolation": "linear",
+                              "lineWidth": 1,
+                              "pointSize": 5,
+                              "scaleDistribution": {
+                                "type": "linear"
+                              },
+                              "showPoints": "auto",
+                              "spanNulls": false,
+                              "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                              },
+                              "thresholdsStyle": {
+                                "mode": "off"
+                              }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                              "mode": "absolute",
+                              "steps": [
+                                {
+                                  "color": "green",
+                                  "value": null
+                                },
+                                {
+                                  "color": "red",
+                                  "value": 80
+                                }
+                              ]
+                            },
+                            "unit": "celsius"
+                          },
+                          "overrides": []
+                        },
+                        "gridPos": {
+                          "h": 8,
+                          "w": 12,
+                          "x": 0,
+                          "y": 9
+                        },
+                        "id": 28,
+                        "options": {
+                          "legend": {
+                            "calcs": [
+                              "mean"
+                            ],
+                            "displayMode": "list",
+                            "placement": "bottom"
+                          },
+                          "tooltip": {
+                            "mode": "single"
+                          }
+                        },
+                        "targets": [
+                          {
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_heating_temperature\" and\r\n    r.site == \"${site}\" and\r\n    r.circuit == \"hc1\" and\r\n    r.state == \"actual\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Actual\":r._value, _time:r._time}))\r\n",
+                            "refId": "Actual"
+                          },
+                          {
+                            "hide": false,
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_heating_temperature\" and\r\n    r.site == \"${site}\" and\r\n    r.circuit == \"hc1\" and\r\n    r.state == \"target\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Target\":r._value, _time:r._time}))\r\n",
+                            "refId": "Target"
+                          }
+                        ],
+                        "title": "Heating Temperature HC 1",
+                        "type": "timeseries"
+                      },
+                      {
+                        "datasource": "${DS_STIEBELELTRON}",
+                        "fieldConfig": {
+                          "defaults": {
+                            "color": {
+                              "mode": "palette-classic"
+                            },
+                            "custom": {
+                              "axisLabel": "",
+                              "axisPlacement": "auto",
+                              "barAlignment": 0,
+                              "drawStyle": "line",
+                              "fillOpacity": 0,
+                              "gradientMode": "none",
+                              "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                              },
+                              "lineInterpolation": "linear",
+                              "lineWidth": 1,
+                              "pointSize": 5,
+                              "scaleDistribution": {
+                                "type": "linear"
+                              },
+                              "showPoints": "auto",
+                              "spanNulls": false,
+                              "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                              },
+                              "thresholdsStyle": {
+                                "mode": "off"
+                              }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                              "mode": "absolute",
+                              "steps": [
+                                {
+                                  "color": "green",
+                                  "value": null
+                                },
+                                {
+                                  "color": "red",
+                                  "value": 80
+                                }
+                              ]
+                            },
+                            "unit": "celsius"
+                          },
+                          "overrides": []
+                        },
+                        "gridPos": {
+                          "h": 8,
+                          "w": 12,
+                          "x": 12,
+                          "y": 9
+                        },
+                        "id": 29,
+                        "options": {
+                          "legend": {
+                            "calcs": [
+                              "mean"
+                            ],
+                            "displayMode": "list",
+                            "placement": "bottom"
+                          },
+                          "tooltip": {
+                            "mode": "single"
+                          }
+                        },
+                        "targets": [
+                          {
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_heating_temperature\" and\r\n    r.site == \"${site}\" and\r\n    r.circuit == \"hc2\" and\r\n    r.state == \"actual\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Actual\":r._value, _time:r._time}))\r\n",
+                            "refId": "Actual"
+                          },
+                          {
+                            "hide": false,
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_heating_temperature\" and\r\n    r.site == \"${site}\" and\r\n    r.circuit == \"hc2\" and\r\n    r.state == \"target\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Target\":r._value, _time:r._time}))\r\n",
+                            "refId": "Target"
+                          }
+                        ],
+                        "title": "Heating Temperature HC 2",
+                        "type": "timeseries"
+                      },
+                      {
+                        "datasource": "${DS_STIEBELELTRON}",
+                        "fieldConfig": {
+                          "defaults": {
+                            "color": {
+                              "mode": "palette-classic"
+                            },
+                            "custom": {
+                              "axisLabel": "",
+                              "axisPlacement": "auto",
+                              "barAlignment": 0,
+                              "drawStyle": "line",
+                              "fillOpacity": 0,
+                              "gradientMode": "none",
+                              "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                              },
+                              "lineInterpolation": "linear",
+                              "lineWidth": 1,
+                              "pointSize": 5,
+                              "scaleDistribution": {
+                                "type": "linear"
+                              },
+                              "showPoints": "auto",
+                              "spanNulls": false,
+                              "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                              },
+                              "thresholdsStyle": {
+                                "mode": "off"
+                              }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                              "mode": "absolute",
+                              "steps": [
+                                {
+                                  "color": "green",
+                                  "value": null
+                                },
+                                {
+                                  "color": "red",
+                                  "value": 80
+                                }
+                              ]
+                            },
+                            "unit": "celsius"
+                          },
+                          "overrides": []
+                        },
+                        "gridPos": {
+                          "h": 8,
+                          "w": 12,
+                          "x": 0,
+                          "y": 17
+                        },
+                        "id": 37,
+                        "interval": null,
+                        "maxDataPoints": null,
+                        "options": {
+                          "legend": {
+                            "calcs": [
+                              "min",
+                              "max",
+                              "mean"
+                            ],
+                            "displayMode": "list",
+                            "placement": "bottom"
+                          },
+                          "tooltip": {
+                            "mode": "single"
+                          }
+                        },
+                        "targets": [
+                          {
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_heating_outside_temperature\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Actual\": r._value, _time: r._time}))\r\n",
+                            "refId": "Outside temp"
+                          }
+                        ],
+                        "title": "Outside Temperature",
+                        "type": "timeseries"
+                      },
+                      {
+                        "datasource": "${DS_STIEBELELTRON}",
+                        "fieldConfig": {
+                          "defaults": {
+                            "color": {
+                              "mode": "palette-classic"
+                            },
+                            "custom": {
+                              "axisLabel": "",
+                              "axisPlacement": "auto",
+                              "barAlignment": 0,
+                              "drawStyle": "line",
+                              "fillOpacity": 0,
+                              "gradientMode": "none",
+                              "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                              },
+                              "lineInterpolation": "linear",
+                              "lineWidth": 1,
+                              "pointSize": 5,
+                              "scaleDistribution": {
+                                "type": "linear"
+                              },
+                              "showPoints": "auto",
+                              "spanNulls": false,
+                              "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                              },
+                              "thresholdsStyle": {
+                                "mode": "off"
+                              }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                              "mode": "absolute",
+                              "steps": [
+                                {
+                                  "color": "green",
+                                  "value": null
+                                },
+                                {
+                                  "color": "red",
+                                  "value": 80
+                                }
+                              ]
+                            },
+                            "unit": "celsius"
+                          },
+                          "overrides": []
+                        },
+                        "gridPos": {
+                          "h": 8,
+                          "w": 12,
+                          "x": 12,
+                          "y": 17
+                        },
+                        "id": 35,
+                        "options": {
+                          "legend": {
+                            "calcs": [
+                              "mean"
+                            ],
+                            "displayMode": "list",
+                            "placement": "bottom"
+                          },
+                          "tooltip": {
+                            "mode": "single"
+                          }
+                        },
+                        "targets": [
+                          {
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_domestic_hotwater_temperature\" and\r\n    r.site == \"${site}\" and\r\n    r.state == \"actual\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Actual\":r._value, _time:r._time}))\r\n",
+                            "refId": "Actual"
+                          },
+                          {
+                            "hide": false,
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_domestic_hotwater_temperature\" and\r\n    r.site == \"${site}\" and\r\n    r.state == \"target\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Target\":r._value, _time:r._time}))\r\n",
+                            "refId": "Target"
+                          }
+                        ],
+                        "title": "Domestic Hotwater Temperature",
+                        "type": "timeseries"
+                      },
+                      {
+                        "datasource": "${DS_STIEBELELTRON}",
+                        "fieldConfig": {
+                          "defaults": {
+                            "color": {
+                              "mode": "palette-classic"
+                            },
+                            "custom": {
+                              "axisLabel": "",
+                              "axisPlacement": "auto",
+                              "barAlignment": 0,
+                              "drawStyle": "line",
+                              "fillOpacity": 0,
+                              "gradientMode": "none",
+                              "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                              },
+                              "lineInterpolation": "linear",
+                              "lineWidth": 1,
+                              "pointSize": 5,
+                              "scaleDistribution": {
+                                "type": "linear"
+                              },
+                              "showPoints": "auto",
+                              "spanNulls": false,
+                              "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                              },
+                              "thresholdsStyle": {
+                                "mode": "off"
+                              }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                              "mode": "absolute",
+                              "steps": [
+                                {
+                                  "color": "green",
+                                  "value": null
+                                },
+                                {
+                                  "color": "red",
+                                  "value": 80
+                                }
+                              ]
+                            },
+                            "unit": "celsius"
+                          },
+                          "overrides": []
+                        },
+                        "gridPos": {
+                          "h": 8,
+                          "w": 12,
+                          "x": 0,
+                          "y": 25
+                        },
+                        "id": 38,
+                        "options": {
+                          "legend": {
+                            "calcs": [
+                              "mean"
+                            ],
+                            "displayMode": "list",
+                            "placement": "bottom"
+                          },
+                          "tooltip": {
+                            "mode": "single"
+                          }
+                        },
+                        "targets": [
+                          {
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_general_temperature_condenser\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Actual\":r._value, _time:r._time}))\r\n",
+                            "refId": "Actual"
+                          }
+                        ],
+                        "title": "Condenser Temperature",
+                        "type": "timeseries"
+                      },
+                      {
+                        "datasource": "${DS_STIEBELELTRON}",
+                        "description": "",
+                        "fieldConfig": {
+                          "defaults": {
+                            "color": {
+                              "mode": "palette-classic"
+                            },
+                            "custom": {
+                              "axisLabel": "",
+                              "axisPlacement": "auto",
+                              "barAlignment": 0,
+                              "drawStyle": "line",
+                              "fillOpacity": 0,
+                              "gradientMode": "none",
+                              "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                              },
+                              "lineInterpolation": "linear",
+                              "lineWidth": 1,
+                              "pointSize": 5,
+                              "scaleDistribution": {
+                                "type": "linear"
+                              },
+                              "showPoints": "auto",
+                              "spanNulls": false,
+                              "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                              },
+                              "thresholdsStyle": {
+                                "mode": "off"
+                              }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                              "mode": "absolute",
+                              "steps": [
+                                {
+                                  "color": "green",
+                                  "value": null
+                                },
+                                {
+                                  "color": "red",
+                                  "value": 80
+                                }
+                              ]
+                            },
+                            "unit": "celsius"
+                          },
+                          "overrides": []
+                        },
+                        "gridPos": {
+                          "h": 8,
+                          "w": 12,
+                          "x": 12,
+                          "y": 25
+                        },
+                        "id": 34,
+                        "options": {
+                          "legend": {
+                            "calcs": [
+                              "mean"
+                            ],
+                            "displayMode": "list",
+                            "placement": "bottom"
+                          },
+                          "tooltip": {
+                            "mode": "single"
+                          }
+                        },
+                        "targets": [
+                          {
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_heating_buffer_temperature\" and\r\n    r.site == \"${site}\" and\r\n    r.state == \"actual\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Actual\":r._value, _time:r._time}))\r\n",
+                            "refId": "Actual"
+                          },
+                          {
+                            "hide": false,
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_heating_buffer_temperature\" and\r\n    r.site == \"${site}\" and\r\n    r.state == \"target\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Target\":r._value, _time:r._time}))\r\n",
+                            "refId": "Target"
+                          }
+                        ],
+                        "title": "Buffer Temperature",
+                        "type": "timeseries"
+                      },
+                      {
+                        "datasource": "${DS_STIEBELELTRON}",
+                        "fieldConfig": {
+                          "defaults": {
+                            "color": {
+                              "mode": "palette-classic"
+                            },
+                            "custom": {
+                              "axisLabel": "",
+                              "axisPlacement": "auto",
+                              "barAlignment": 0,
+                              "drawStyle": "line",
+                              "fillOpacity": 0,
+                              "gradientMode": "none",
+                              "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                              },
+                              "lineInterpolation": "linear",
+                              "lineWidth": 1,
+                              "pointSize": 5,
+                              "scaleDistribution": {
+                                "type": "linear"
+                              },
+                              "showPoints": "auto",
+                              "spanNulls": false,
+                              "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                              },
+                              "thresholdsStyle": {
+                                "mode": "off"
+                              }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                              "mode": "absolute",
+                              "steps": [
+                                {
+                                  "color": "green",
+                                  "value": null
+                                },
+                                {
+                                  "color": "red",
+                                  "value": 80
+                                }
+                              ]
+                            },
+                            "unit": "celsius"
+                          },
+                          "overrides": []
+                        },
+                        "gridPos": {
+                          "h": 8,
+                          "w": 12,
+                          "x": 0,
+                          "y": 33
+                        },
+                        "id": 31,
+                        "options": {
+                          "legend": {
+                            "calcs": [
+                              "mean"
+                            ],
+                            "displayMode": "list",
+                            "placement": "bottom"
+                          },
+                          "tooltip": {
+                            "mode": "single"
+                          }
+                        },
+                        "targets": [
+                          {
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_heating_flow_temperature\" and\r\n    r.site == \"${site}\" and\r\n    r.type == \"heatpump\" and\r\n    r.state == \"actual\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Heatpump\":r._value, _time:r._time}))\r\n",
+                            "refId": "Heatpump"
+                          },
+                          {
+                            "hide": false,
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_heating_flow_temperature\" and\r\n    r.site == \"${site}\" and\r\n    r.type == \"reheating\" and\r\n    r.state == \"actual\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Reheating\":r._value, _time:r._time}))\r\n",
+                            "refId": "Reheating"
+                          },
+                          {
+                            "hide": false,
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_heating_flow_temperature\" and\r\n    r.site == \"${site}\" and\r\n    r.type == \"preflow\" and\r\n    r.state == \"actual\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Pre-Flow\":r._value, _time:r._time}))\r\n",
+                            "refId": "Pre-Flow"
+                          }
+                        ],
+                        "title": "Flow Temperature",
+                        "type": "timeseries"
+                      },
+                      {
+                        "collapsed": false,
+                        "datasource": null,
+                        "gridPos": {
+                          "h": 1,
+                          "w": 24,
+                          "x": 0,
+                          "y": 41
+                        },
+                        "id": 44,
+                        "panels": [],
+                        "title": "Pump Stats",
+                        "type": "row"
+                      },
+                      {
+                        "datasource": "${DS_STIEBELELTRON}",
+                        "fieldConfig": {
+                          "defaults": {
+                            "color": {
+                              "mode": "palette-classic"
+                            },
+                            "custom": {
+                              "axisLabel": "",
+                              "axisPlacement": "auto",
+                              "barAlignment": 0,
+                              "drawStyle": "line",
+                              "fillOpacity": 0,
+                              "gradientMode": "none",
+                              "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                              },
+                              "lineInterpolation": "linear",
+                              "lineWidth": 1,
+                              "pointSize": 5,
+                              "scaleDistribution": {
+                                "type": "linear"
+                              },
+                              "showPoints": "auto",
+                              "spanNulls": false,
+                              "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                              },
+                              "thresholdsStyle": {
+                                "mode": "off"
+                              }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                              "mode": "absolute",
+                              "steps": [
+                                {
+                                  "color": "green",
+                                  "value": null
+                                },
+                                {
+                                  "color": "red",
+                                  "value": 80
+                                }
+                              ]
+                            },
+                            "unit": "percentunit"
+                          },
+                          "overrides": []
+                        },
+                        "gridPos": {
+                          "h": 8,
+                          "w": 12,
+                          "x": 0,
+                          "y": 42
+                        },
+                        "id": 46,
+                        "options": {
+                          "legend": {
+                            "calcs": [
+                              "max",
+                              "mean"
+                            ],
+                            "displayMode": "list",
+                            "placement": "bottom"
+                          },
+                          "tooltip": {
+                            "mode": "single"
+                          }
+                        },
+                        "targets": [
+                          {
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_general_output_activity_ratio\" and\r\n    r.site == \"${site}\" and\r\n    r.pump == \"heat\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Heat Pump\":r._value, _time:r._time}))\r\n",
+                            "refId": "Heatpump"
+                          },
+                          {
+                            "hide": false,
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_general_output_activity_ratio\" and\r\n    r.site == \"${site}\" and\r\n    r.pump == \"water\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Water Pump\":r._value, _time:r._time}))\r\n",
+                            "refId": "Water Pump"
+                          }
+                        ],
+                        "title": "Pump Activity",
+                        "type": "timeseries"
+                      },
+                      {
+                        "datasource": "${DS_STIEBELELTRON}",
+                        "fieldConfig": {
+                          "defaults": {
+                            "color": {
+                              "mode": "palette-classic"
+                            },
+                            "custom": {
+                              "axisLabel": "",
+                              "axisPlacement": "auto",
+                              "barAlignment": 0,
+                              "drawStyle": "line",
+                              "fillOpacity": 0,
+                              "gradientMode": "none",
+                              "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                              },
+                              "lineInterpolation": "linear",
+                              "lineWidth": 1,
+                              "pointSize": 5,
+                              "scaleDistribution": {
+                                "type": "linear"
+                              },
+                              "showPoints": "auto",
+                              "spanNulls": false,
+                              "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                              },
+                              "thresholdsStyle": {
+                                "mode": "off"
+                              }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                              "mode": "absolute",
+                              "steps": [
+                                {
+                                  "color": "green",
+                                  "value": null
+                                },
+                                {
+                                  "color": "red",
+                                  "value": 80
+                                }
+                              ]
+                            },
+                            "unit": "pressurebar"
+                          },
+                          "overrides": []
+                        },
+                        "gridPos": {
+                          "h": 8,
+                          "w": 12,
+                          "x": 12,
+                          "y": 42
+                        },
+                        "id": 47,
+                        "options": {
+                          "legend": {
+                            "calcs": [
+                              "min",
+                              "max",
+                              "mean"
+                            ],
+                            "displayMode": "list",
+                            "placement": "bottom"
+                          },
+                          "tooltip": {
+                            "mode": "single"
+                          }
+                        },
+                        "targets": [
+                          {
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_general_heating_circuit_pressure\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Pressure\":r._value, _time:r._time}))\r\n",
+                            "refId": "Heatpump"
+                          }
+                        ],
+                        "title": "Circuit Pressure",
+                        "type": "timeseries"
+                      },
+                      {
+                        "datasource": "${DS_STIEBELELTRON}",
+                        "fieldConfig": {
+                          "defaults": {
+                            "color": {
+                              "mode": "palette-classic"
+                            },
+                            "custom": {
+                              "axisLabel": "",
+                              "axisPlacement": "auto",
+                              "barAlignment": 0,
+                              "drawStyle": "line",
+                              "fillOpacity": 0,
+                              "gradientMode": "none",
+                              "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                              },
+                              "lineInterpolation": "linear",
+                              "lineWidth": 1,
+                              "pointSize": 5,
+                              "scaleDistribution": {
+                                "type": "linear"
+                              },
+                              "showPoints": "auto",
+                              "spanNulls": false,
+                              "stacking": {
+                                "group": "A",
+                                "mode": "none"
+                              },
+                              "thresholdsStyle": {
+                                "mode": "off"
+                              }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                              "mode": "absolute",
+                              "steps": [
+                                {
+                                  "color": "green",
+                                  "value": null
+                                },
+                                {
+                                  "color": "red",
+                                  "value": 80
+                                }
+                              ]
+                            },
+                            "unit": "s"
+                          },
+                          "overrides": []
+                        },
+                        "gridPos": {
+                          "h": 8,
+                          "w": 12,
+                          "x": 0,
+                          "y": 50
+                        },
+                        "id": 48,
+                        "options": {
+                          "legend": {
+                            "calcs": [
+                              "max"
+                            ],
+                            "displayMode": "list",
+                            "placement": "bottom"
+                          },
+                          "tooltip": {
+                            "mode": "single"
+                          }
+                        },
+                        "targets": [
+                          {
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_process_data_compressor_delay_counter\" and\r\n    r.site == \"${site}\"\r\n  )\r\n  |> group(columns: [\"site\"])\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> map(fn: (r) => ({\"Compressor Duration Timer\":r._value, _time:r._time}))\r\n",
+                            "refId": "Heatpump"
+                          }
+                        ],
+                        "title": "Compressor Duration Timer",
+                        "type": "timeseries"
+                      },
+                      {
+                        "collapsed": false,
+                        "datasource": null,
+                        "gridPos": {
+                          "h": 1,
+                          "w": 24,
+                          "x": 0,
+                          "y": 58
+                        },
+                        "id": 13,
+                        "panels": [],
+                        "title": "Energy",
+                        "type": "row"
+                      },
+                      {
+                        "datasource": "${DS_STIEBELELTRON}",
+                        "fieldConfig": {
+                          "defaults": {
+                            "color": {
+                              "mode": "palette-classic"
+                            },
+                            "custom": {
+                              "axisLabel": "",
+                              "axisPlacement": "auto",
+                              "barAlignment": 1,
+                              "drawStyle": "bars",
+                              "fillOpacity": 10,
+                              "gradientMode": "none",
+                              "hideFrom": {
+                                "legend": false,
+                                "tooltip": false,
+                                "viz": false
+                              },
+                              "lineInterpolation": "stepBefore",
+                              "lineWidth": 1,
+                              "pointSize": 18,
+                              "scaleDistribution": {
+                                "type": "linear"
+                              },
+                              "showPoints": "never",
+                              "spanNulls": true,
+                              "stacking": {
+                                "group": "A",
+                                "mode": "normal"
+                              },
+                              "thresholdsStyle": {
+                                "mode": "off"
+                              }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                              "mode": "absolute",
+                              "steps": [
+                                {
+                                  "color": "green",
+                                  "value": null
+                                },
+                                {
+                                  "color": "red",
+                                  "value": 80
+                                }
+                              ]
+                            },
+                            "unit": "watth"
+                          },
+                          "overrides": []
+                        },
+                        "gridPos": {
+                          "h": 8,
+                          "w": 12,
+                          "x": 0,
+                          "y": 59
+                        },
+                        "id": 10,
+                        "options": {
+                          "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom"
+                          },
+                          "tooltip": {
+                            "mode": "single"
+                          }
+                        },
+                        "pluginVersion": "8.2.3",
+                        "targets": [
+                          {
+                            "groupBy": [
+                              {
+                                "params": [
+                                  "$__interval"
+                                ],
+                                "type": "time"
+                              },
+                              {
+                                "params": [
+                                  "null"
+                                ],
+                                "type": "fill"
+                              }
+                            ],
+                            "orderByTime": "ASC",
+                            "policy": "default",
+                            "query": "import \"strings\"\r\nimport \"date\"\r\n\r\ndividyByX = (x, tables=<-) =>\r\n  tables\r\n    |> map(fn: (r) => ({\r\n        r with\r\n        _value: r._value / x\r\n      })\r\n    )\r\n\r\nfrom(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_energy_heating_total\" and\r\n    r.site == \"${site}\" and\r\n    r.compressor == \"heating\" and\r\n    r.timeframe == \"day\"\r\n  )\r\n  |> drop(columns: [\"url\", \"host\", \"timeframe\"])\r\n  |> window(every: 24h)\r\n  |> max()\r\n  |> group(columns: [\"site\"])\r\n  |> dividyByX(x: 3600.0)\r\n  |> map(fn: (r) => ({\"Compressor\": r._value, _time: date.truncate(t: r._time, unit: 1d)}))",
+                            "refId": "Heating",
+                            "resultFormat": "time_series",
+                            "select": [
+                              [
+                                {
+                                  "params": [
+                                    "value"
+                                  ],
+                                  "type": "field"
+                                },
+                                {
+                                  "params": [],
+                                  "type": "mean"
+                                }
+                              ]
+                            ],
+                            "tags": []
+                          },
+                          {
+                            "groupBy": [
+                              {
+                                "params": [
+                                  "$__interval"
+                                ],
+                                "type": "time"
+                              },
+                              {
+                                "params": [
+                                  "null"
+                                ],
+                                "type": "fill"
+                              }
+                            ],
+                            "hide": false,
+                            "orderByTime": "ASC",
+                            "policy": "default",
+                            "query": "import \"strings\"\r\nimport \"date\"\r\n\r\ndividyByX = (x, tables=<-) =>\r\n  tables\r\n    |> map(fn: (r) => ({\r\n        r with\r\n        _value: r._value / x\r\n      })\r\n    )\r\n\r\nfrom(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_energy_heating_total\" and\r\n    r.site == \"${site}\" and\r\n    r.compressor == \"domestic_hotwater\" and\r\n    r.timeframe == \"day\"\r\n  )\r\n  |> drop(columns: [\"url\", \"host\", \"timeframe\"])\r\n  |> window(every: 24h)\r\n  |> max()\r\n  |> group(columns: [\"site\"])\r\n  |> dividyByX(x: 3600.0)\r\n  |> map(fn: (r) => ({\"Domestic Hotwater\": r._value, _time: date.truncate(t: r._time, unit: 1d)}))",
+                            "refId": "Domestic Hotwater",
+                            "resultFormat": "time_series",
+                            "select": [
+                              [
+                                {
+                                  "params": [
+                                    "value"
+                                  ],
+                                  "type": "field"
+                                },
+                                {
+                                  "params": [],
+                                  "type": "mean"
+                                }
+                              ]
+                            ],
+                            "tags": []
+                          }
+                        ],
+                        "timeFrom": null,
+                        "timeShift": null,
+                        "title": "Total Energy per day",
+                        "type": "timeseries"
+                      },
+                      {
+                        "datasource": "${DS_STIEBELELTRON}",
+                        "fieldConfig": {
+                          "defaults": {
+                            "color": {
+                              "mode": "thresholds"
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                              "mode": "absolute",
+                              "steps": [
+                                {
+                                  "color": "green",
+                                  "value": null
+                                }
+                              ]
+                            },
+                            "unit": "watth"
+                          },
+                          "overrides": []
+                        },
+                        "gridPos": {
+                          "h": 8,
+                          "w": 2,
+                          "x": 12,
+                          "y": 59
+                        },
+                        "id": 36,
+                        "options": {
+                          "colorMode": "value",
+                          "graphMode": "area",
+                          "justifyMode": "auto",
+                          "orientation": "vertical",
+                          "reduceOptions": {
+                            "calcs": [
+                              "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": true
+                          },
+                          "text": {},
+                          "textMode": "auto"
+                        },
+                        "pluginVersion": "8.2.3",
+                        "targets": [
+                          {
+                            "groupBy": [
+                              {
+                                "params": [
+                                  "$__interval"
+                                ],
+                                "type": "time"
+                              },
+                              {
+                                "params": [
+                                  "null"
+                                ],
+                                "type": "fill"
+                              }
+                            ],
+                            "orderByTime": "ASC",
+                            "policy": "default",
+                            "query": "dividyByX = (x, tables=<-) =>\r\n  tables\r\n    |> map(fn: (r) => ({\r\n        r with\r\n        _value: r._value / x\r\n      })\r\n    )\r\n\r\nfrom(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_energy_heating_total\" and\r\n    r.site == \"${site}\" and\r\n    r.timeframe == \"day\"\r\n  )\r\n  |> pivot(\r\n    rowKey: [\"_time\"],\r\n    columnKey: [\"compressor\"],\r\n    valueColumn: \"_value\"\r\n  )\r\n  |> map(fn: (r) => (\r\n    {_value: r.domestic_hotwater + r.heating, _time: r._time}\r\n  ))\r\n  |> window(every: 24h)\r\n  |> max()\r\n  |> drop(columns: [\"_start\", \"_stop\"])\r\n  |> mean()\r\n  |> dividyByX(x: 3600.0)",
+                            "refId": "Energy per day",
+                            "resultFormat": "time_series",
+                            "select": [
+                              [
+                                {
+                                  "params": [
+                                    "value"
+                                  ],
+                                  "type": "field"
+                                },
+                                {
+                                  "params": [],
+                                  "type": "mean"
+                                }
+                              ]
+                            ],
+                            "tags": []
+                          }
+                        ],
+                        "title": "Average Energy per day",
+                        "type": "stat"
+                      },
+                      {
+                        "collapsed": false,
+                        "datasource": null,
+                        "gridPos": {
+                          "h": 1,
+                          "w": 24,
+                          "x": 0,
+                          "y": 67
+                        },
+                        "id": 40,
+                        "panels": [],
+                        "title": "Runtime",
+                        "type": "row"
+                      },
+                      {
+                        "datasource": "${DS_STIEBELELTRON}",
+                        "description": "",
+                        "fieldConfig": {
+                          "defaults": {
+                            "color": {
+                              "mode": "thresholds"
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                              "mode": "absolute",
+                              "steps": [
+                                {
+                                  "color": "green",
+                                  "value": null
+                                }
+                              ]
+                            },
+                            "unit": "s"
+                          },
+                          "overrides": []
+                        },
+                        "gridPos": {
+                          "h": 5,
+                          "w": 6,
+                          "x": 0,
+                          "y": 68
+                        },
+                        "id": 42,
+                        "options": {
+                          "colorMode": "none",
+                          "graphMode": "none",
+                          "justifyMode": "auto",
+                          "orientation": "auto",
+                          "reduceOptions": {
+                            "calcs": [
+                              "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                          },
+                          "text": {},
+                          "textMode": "auto"
+                        },
+                        "pluginVersion": "8.2.3",
+                        "targets": [
+                          {
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_runtime_compressor\" and\r\n    r.site == \"${site}\" and\r\n    r.compressor == \"heating\"\r\n  )\r\n  |> last()\r\n  |> map(fn: (r) => ({\"Heating\": r._value}))\r\n",
+                            "refId": "Heating"
+                          },
+                          {
+                            "hide": false,
+                            "query": "from(bucket: \"${bucket}\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn:(r) =>\r\n    r._measurement == \"stiebeleltron_runtime_compressor\" and\r\n    r.site == \"${site}\" and\r\n    r.compressor == \"domestic_hotwater\"\r\n  )\r\n  |> last()\r\n  |> map(fn: (r) => ({\"Domestic Hotwater\": r._value}))\r\n",
+                            "refId": "Domestic Hotwater"
+                          }
+                        ],
+                        "title": "Total Runtime",
+                        "type": "stat"
+                      }
+                    ],
+                      "refresh": false,
+                        "schemaVersion": 31,
+                          "style": "dark",
+                            "tags": [],
+                              "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "stiebeleltron",
+          "value": "stiebeleltron"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "influxdb",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "/.*stiebeleltron.*/",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_STIEBELELTRON}",
+        "definition": "buckets()\r\n  |> filter(fn: (r) => r.name != \"_monitoring\" and r.name != \"_tasks\")",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Bucket",
+        "multi": false,
+        "name": "bucket",
+        "options": [],
+        "query": "buckets()\r\n  |> filter(fn: (r) => r.name != \"_monitoring\" and r.name != \"_tasks\")",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_STIEBELELTRON}",
+        "definition": "import \"influxdata/influxdb/v1\"\r\nv1.tagValues(\r\n    bucket: \"${bucket}\",\r\n    tag: \"site\",\r\n    predicate: (r) => true,\r\n    start: -180d\r\n)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Site",
+        "multi": false,
+        "name": "site",
+        "options": [],
+        "query": "import \"influxdata/influxdb/v1\"\r\nv1.tagValues(\r\n    bucket: \"${bucket}\",\r\n    tag: \"site\",\r\n    predicate: (r) => true,\r\n    start: -180d\r\n)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+      "to": "now"
+  },
+  "timepicker": { },
+  "timezone": "",
+    "title": "Stiebel Eltron",
+      "uid": "8yehZtTnz",
+        "version": 17
+}

--- a/charts/stiebeleltron-stack/files/influxdb/migration/domestic_hotwater_temperature_actual.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/domestic_hotwater_temperature_actual.flux
@@ -1,0 +1,17 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.hotwater.hotwatertemp.actual"
+tMeasurement = "stiebeleltron_domestic_hotwater_temperature"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "state", value: "actual")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/domestic_hotwater_temperature_target.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/domestic_hotwater_temperature_target.flux
@@ -1,0 +1,17 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.hotwater.hotwatertemp.set"
+tMeasurement = "stiebeleltron_domestic_hotwater_temperature"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "state", value: "target")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/electric_reheating_dualmode_reheating_temperatur_heating.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/electric_reheating_dualmode_reheating_temperatur_heating.flux
@@ -1,0 +1,17 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.eletricreheating.reheatingtemp.heating"
+tMeasurement = "stiebeleltron_electric_reheating_dualmode_reheating_temperature"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "sensor", value: "heating")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/electric_reheating_dualmode_reheating_temperatur_hotwater.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/electric_reheating_dualmode_reheating_temperatur_hotwater.flux
@@ -1,0 +1,17 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.eletricreheating.reheatingtemp.hot_water"
+tMeasurement = "stiebeleltron_electric_reheating_dualmode_reheating_temperature"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "sensor", value: "domestic_hotwater")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/energy_heating_total_dhw_day.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/energy_heating_total_dhw_day.flux
@@ -1,0 +1,27 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_heatpump.energy.compressorday.hot_water"
+tMeasurement = "stiebeleltron_energy_heating_total"
+site = "sirius"
+
+multiplyByX = (x, tables=<-) =>
+  tables
+    |> map(fn: (r) => ({
+        r with
+        _value: r._value * x
+      })
+    )
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> multiplyByX(x: 3600000.0)
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "timeframe", value: "day")
+  |> set(key: "compressor", value: "domestic_hotwater")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/energy_heating_total_dhw_total.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/energy_heating_total_dhw_total.flux
@@ -1,0 +1,27 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_heatpump.energy.compressortotal.hot_water"
+tMeasurement = "stiebeleltron_energy_heating_total"
+site = "sirius"
+
+multiplyByX = (x, tables=<-) =>
+  tables
+    |> map(fn: (r) => ({
+        r with
+        _value: r._value * x
+      })
+    )
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> multiplyByX(x: 3600000000.0)
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "timeframe", value: "total")
+  |> set(key: "compressor", value: "domestic_hotwater")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/energy_heating_total_heating_day.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/energy_heating_total_heating_day.flux
@@ -1,0 +1,27 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_heatpump.energy.compressorday.heating"
+tMeasurement = "stiebeleltron_energy_heating_total"
+site = "sirius"
+
+multiplyByX = (x, tables=<-) =>
+  tables
+    |> map(fn: (r) => ({
+        r with
+        _value: r._value * x
+      })
+    )
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> multiplyByX(x: 3600000.0)
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "timeframe", value: "day")
+  |> set(key: "compressor", value: "heating")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/energy_heating_total_heating_total.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/energy_heating_total_heating_total.flux
@@ -1,0 +1,27 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_heatpump.energy.compressortotal.heating"
+tMeasurement = "stiebeleltron_energy_heating_total"
+site = "sirius"
+
+multiplyByX = (x, tables=<-) =>
+  tables
+    |> map(fn: (r) => ({
+        r with
+        _value: r._value * x
+      })
+    )
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> multiplyByX(x: 3600000000.0)
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "timeframe", value: "total")
+  |> set(key: "compressor", value: "heating")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/general_flow.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/general_flow.flux
@@ -1,0 +1,25 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.general.flowrate.flow_rate"
+tMeasurement = "stiebeleltron_general_flow"
+site = "sirius"
+
+multiplyByX = (x, tables=<-) =>
+  tables
+    |> map(fn: (r) => ({
+        r with
+        _value: r._value * x
+      })
+    )
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> multiplyByX(x: 0.01)
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/general_heating_circuit_pressure.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/general_heating_circuit_pressure.flux
@@ -1,0 +1,16 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.general.heatingcircuit.heating_circuit"
+tMeasurement = "stiebeleltron_general_heating_circuit_pressure"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/general_output_activity_ratio_heat.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/general_output_activity_ratio_heat.flux
@@ -1,0 +1,26 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.general.output.heat_pump"
+tMeasurement = "stiebeleltron_general_output_activity_ratio"
+site = "sirius"
+
+multiplyByX = (x, tables=<-) =>
+  tables
+    |> map(fn: (r) => ({
+        r with
+        _value: r._value * x
+      })
+    )
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> multiplyByX(x: 0.01)
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "pump", value: "heat")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/general_output_activity_ratio_water.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/general_output_activity_ratio_water.flux
@@ -1,0 +1,26 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.general.output.water_pump"
+tMeasurement = "stiebeleltron_general_output_activity_ratio"
+site = "sirius"
+
+multiplyByX = (x, tables=<-) =>
+  tables
+    |> map(fn: (r) => ({
+        r with
+        _value: r._value * x
+      })
+    )
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> multiplyByX(x: 0.01)
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "pump", value: "water")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/general_temperature_condenser.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/general_temperature_condenser.flux
@@ -1,0 +1,16 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.general.condenser.condenser"
+tMeasurement = "stiebeleltron_general_temperature_condenser"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/general_temperature_outside.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/general_temperature_outside.flux
@@ -1,0 +1,16 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.general.outside.outside_temperature"
+tMeasurement = "stiebeleltron_general_temperature_outside"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/heating_buffer_temperature_actual.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/heating_buffer_temperature_actual.flux
@@ -1,0 +1,17 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.heating.buffertemp.actual"
+tMeasurement = "stiebeleltron_heating_buffer_temperature"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "state", value: "actual")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/heating_buffer_temperature_target.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/heating_buffer_temperature_target.flux
@@ -1,0 +1,17 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.heating.buffertemp.set"
+tMeasurement = "stiebeleltron_heating_buffer_temperature"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "state", value: "target")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/heating_fixed_temperature.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/heating_fixed_temperature.flux
@@ -1,0 +1,17 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.heating.fixedtemp.set"
+tMeasurement = "stiebeleltron_heating_fixed_temperature"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "state", value: "target")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/heating_flow_temperature_heatpump.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/heating_flow_temperature_heatpump.flux
@@ -1,0 +1,18 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.heating.flowtemp.heating"
+tMeasurement = "stiebeleltron_heating_flow_temperature"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "state", value: "actual")
+  |> set(key: "type", value: "heatpump")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/heating_flow_temperature_preflow.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/heating_flow_temperature_preflow.flux
@@ -1,0 +1,18 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.heating.preflowtemp.actual"
+tMeasurement = "stiebeleltron_heating_flow_temperature"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "state", value: "actual")
+  |> set(key: "type", value: "preflow")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/heating_flow_temperature_reheating.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/heating_flow_temperature_reheating.flux
@@ -1,0 +1,18 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.heating.flowtemp.reheating"
+tMeasurement = "stiebeleltron_heating_flow_temperature"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "state", value: "actual")
+  |> set(key: "type", value: "reheating")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/heating_outside_temperature.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/heating_outside_temperature.flux
@@ -1,7 +1,7 @@
 sBucket = "netdata/autogen"
 tBucket = "stiebeleltron_archive"
 sMeasurement = "netdata.heating.stiebeleltron_system.general.outside.outside_temperature"
-tMeasurement = "stiebeleltron_general_temperature_outside"
+tMeasurement = "stiebeleltron_heating_outside_temperature"
 site = "sirius"
 
 from(bucket: sBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/heating_temperature_hc1_actual.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/heating_temperature_hc1_actual.flux
@@ -1,0 +1,18 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.heating.hc1.actual"
+tMeasurement = "stiebeleltron_heating_temperature"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "state", value: "actual")
+  |> set(key: "circuit", value: "hc1")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/heating_temperature_hc1_target.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/heating_temperature_hc1_target.flux
@@ -1,0 +1,18 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.heating.hc1.set"
+tMeasurement = "stiebeleltron_heating_temperature"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "state", value: "target")
+  |> set(key: "circuit", value: "hc1")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/heating_temperature_hc2_actual.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/heating_temperature_hc2_actual.flux
@@ -1,0 +1,18 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.heating.hc2.actual"
+tMeasurement = "stiebeleltron_heating_temperature"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "state", value: "actual")
+  |> set(key: "circuit", value: "hc2")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/heating_temperature_hc2_target.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/heating_temperature_hc2_target.flux
@@ -1,0 +1,18 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.heating.hc2.set"
+tMeasurement = "stiebeleltron_heating_temperature"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "state", value: "target")
+  |> set(key: "circuit", value: "hc2")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/process_data_compressor_delay_counter.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/process_data_compressor_delay_counter.flux
@@ -1,0 +1,16 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_heatpump.processdata.remaincomp.timer"
+tMeasurement = "stiebeleltron_process_data_compressor_delay_counter"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/room_temperature_heating_circuit_hc1_actual.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/room_temperature_heating_circuit_hc1_actual.flux
@@ -1,0 +1,18 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.roomtemp.hc1.actual"
+tMeasurement = "stiebeleltron_room_temperature_heating_circuit"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "state", value: "actual")
+  |> set(key: "circuit", value: "hc1")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/room_temperature_heating_circuit_hc1_target.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/room_temperature_heating_circuit_hc1_target.flux
@@ -1,0 +1,18 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.roomtemp.hc1.set"
+tMeasurement = "stiebeleltron_room_temperature_heating_circuit"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "state", value: "target")
+  |> set(key: "circuit", value: "hc1")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/room_temperature_heating_circuit_hc2_actual.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/room_temperature_heating_circuit_hc2_actual.flux
@@ -1,0 +1,18 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.roomtemp.hc2.actual"
+tMeasurement = "stiebeleltron_room_temperature_heating_circuit"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "state", value: "actual")
+  |> set(key: "circuit", value: "hc2")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/room_temperature_heating_circuit_hc2_target.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/room_temperature_heating_circuit_hc2_target.flux
@@ -1,0 +1,18 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_system.roomtemp.hc2.set"
+tMeasurement = "stiebeleltron_room_temperature_heating_circuit"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "state", value: "target")
+  |> set(key: "circuit", value: "hc2")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/runtime_compressor_dhw.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/runtime_compressor_dhw.flux
@@ -1,0 +1,26 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_heatpump.runtime.compressor.hot_water"
+tMeasurement = "stiebeleltron_runtime_compressor"
+site = "sirius"
+
+multiplyByX = (x, tables=<-) =>
+  tables
+    |> map(fn: (r) => ({
+        r with
+        _value: r._value * x
+      })
+    )
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> multiplyByX(x: 3600.0)
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "compressor", value: "domestic_hotwater")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/runtime_compressor_heating.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/runtime_compressor_heating.flux
@@ -1,0 +1,26 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_heatpump.runtime.compressor.heating"
+tMeasurement = "stiebeleltron_runtime_compressor"
+site = "sirius"
+
+multiplyByX = (x, tables=<-) =>
+  tables
+    |> map(fn: (r) => ({
+        r with
+        _value: r._value * x
+      })
+    )
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> multiplyByX(x: 3600.0)
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "compressor", value: "heating")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/runtime_reheating_1.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/runtime_reheating_1.flux
@@ -1,0 +1,17 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_heatpump.runtime.reheating.reheating_1"
+tMeasurement = "stiebeleltron_runtime_reheating"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "circuit", value: "hc1")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/migration/runtime_reheating_2.flux
+++ b/charts/stiebeleltron-stack/files/influxdb/migration/runtime_reheating_2.flux
@@ -1,0 +1,17 @@
+sBucket = "netdata/autogen"
+tBucket = "stiebeleltron_archive"
+sMeasurement = "netdata.heating.stiebeleltron_heatpump.runtime.reheating.reheating_2"
+tMeasurement = "stiebeleltron_runtime_reheating"
+site = "sirius"
+
+from(bucket: sBucket)
+  |> range(start: -5y, stop: 0s)
+  |> filter(fn:(r) =>
+    r._measurement == sMeasurement
+  )
+  |> map(fn: (r) => ({r with _measurement: tMeasurement}))
+  |> aggregateWindow(every: 10m, fn: mean, createEmpty: false)
+  |> set(key: "site", value: site)
+  |> set(key: "circuit", value: "hc2")
+  |> set(key: "_field", value: "gauge")
+  |> to(bucket: tBucket)

--- a/charts/stiebeleltron-stack/files/influxdb/task.sh
+++ b/charts/stiebeleltron-stack/files/influxdb/task.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo "creating bucket ${INFLUX_BUCKET_NAME}"
+response=$(influx bucket create -r ${INFLUX_BUCKET_RETENTION})
+exit_code=$?
+echo "$response"
+if [[ "$response" != *"already exists"* && $exit_code -gt 0 ]]; then
+  exit $exit_code
+fi
+
+echo "listing existing tasks"
+response=$(influx task list)
+if [[ "$response" == *"Downsampling Fronius"* ]]; then
+  echo "task exists already, nothing to do"
+  exit 0
+fi
+
+echo "creating task"
+influx task create -f /config/task.flux

--- a/charts/stiebeleltron-stack/files/influxdb/task.sh
+++ b/charts/stiebeleltron-stack/files/influxdb/task.sh
@@ -10,7 +10,7 @@ fi
 
 echo "listing existing tasks"
 response=$(influx task list)
-if [[ "$response" == *"Downsampling Fronius"* ]]; then
+if [[ "$response" == *"Downsampling Stiebeleltron"* ]]; then
   echo "task exists already, nothing to do"
   exit 0
 fi

--- a/charts/stiebeleltron-stack/templates/_helpers.tpl
+++ b/charts/stiebeleltron-stack/templates/_helpers.tpl
@@ -1,0 +1,91 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "stiebeleltron-stack.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "stiebeleltron-stack.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "stiebeleltron-stack.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "stiebeleltron-stack.labels" -}}
+helm.sh/chart: {{ include "stiebeleltron-stack.chart" . }}
+{{ include "stiebeleltron-stack.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "stiebeleltron-stack.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "stiebeleltron-stack.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "stiebeleltron-stack.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "stiebeleltron-stack.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the full service name
+*/}}
+{{- define "stiebeleltron-stack.tld" -}}
+{{ .Release.Namespace }}
+{{- end }}
+{{- define "stiebeleltron-stack.influxdb-host" -}}
+http://{{ template "influxdb.fullname" . }}-influxdb.{{ .Release.Namespace }}:{{ .Values.influxdb.service.port | default 80 }}
+{{- end }}
+
+{{/*
+Helper to define env vars for influxdb jobs
+*/}}
+{{- define "stiebeleltron-stack.influxdb-env" -}}
+- name: INFLUX_HOST
+  value: {{ template "stiebeleltron-stack.influxdb-host" . }}
+- name: INFLUX_ORG
+  value: {{ .Values.influxdb.adminUser.organization }}
+- name: INFLUX_TOKEN
+  valueFrom:
+    secretKeyRef:
+      {{- if .Values.influxdb.adminUser.existingSecret }}
+      name: {{ .Values.influxdb.adminUser.existingSecret -}}
+      {{ else }}
+      name: {{ template "stiebeleltron-stack.fullname" . }}-influxdb-auth
+      {{- end }}
+      key: admin-token
+{{- end }}

--- a/charts/stiebeleltron-stack/templates/grafana/cm-dashboard.yaml
+++ b/charts/stiebeleltron-stack/templates/grafana/cm-dashboard.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.grafana.dashboard.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "stiebeleltron-stack.fullname" . }}-dashboard
+  namespace: {{ default .Release.Namespace .Values.grafana.dashboard.namespace }}
+  labels:
+    {{- include "stiebeleltron-stack.labels" . | nindent 4 }}
+    {{- toYaml .Values.grafana.dashboard.labels | nindent 4}}
+  {{- if .Values.grafana.dashboard.annotations }}
+  annotations:
+    {{- toYaml .Values.grafana.dashboard.annotations | nindent 4 }}
+  {{- end }}
+data:
+  {{ (.Files.Glob "files/grafana/*.json").AsConfig | nindent 2 }}
+{{- end -}}

--- a/charts/stiebeleltron-stack/templates/grafana/secret-datasource.yaml
+++ b/charts/stiebeleltron-stack/templates/grafana/secret-datasource.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.grafana.datasource.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "stiebeleltron-stack.fullname" . }}-datasource
+  namespace: {{ default .Release.Namespace .Values.grafana.datasource.namespace }}
+  labels:
+    {{- include "stiebeleltron-stack.labels" . | nindent 4 }}
+    {{- toYaml .Values.grafana.datasource.labels | nindent 4}}
+  {{- if .Values.grafana.datasource.annotations }}
+  annotations:
+    {{- toYaml .Values.grafana.datasource.annotations | nindent 4 }}
+  {{- end }}
+stringData:
+  {{ template "stiebeleltron-stack.fullname" . }}.yaml: |-
+    apiVersion: 1
+    datasources:
+    - name: {{ template "stiebeleltron-stack.fullname" . }}
+      type: influxdb
+      url: {{ include "stiebeleltron-stack.influxdb-host" . }}
+      isDefault: false
+      secureJsonData:
+        token: {{ .Values.stiebeleltron.telegraf.influxdb.token }}
+      jsonData:
+        httpMode: POST
+        timeInterval: {{ .Values.stiebeleltron.telegraf.interval }}
+        version: Flux
+        defaultBucket: {{ .Values.stiebeleltron.telegraf.influxdb.bucket }}
+        organization: {{ .Values.stiebeleltron.telegraf.influxdb.organization }}
+{{- end -}}

--- a/charts/stiebeleltron-stack/templates/influxdb/cm-influxdb-task.yaml
+++ b/charts/stiebeleltron-stack/templates/influxdb/cm-influxdb-task.yaml
@@ -9,7 +9,7 @@ data:
   task.flux: |
     import "strings"
 
-    option task = {name: "Downsampling stiebeleltron", every: {{ .Values.archival.window }}}
+    option task = {name: "Downsampling Stiebeleltron", every: {{ .Values.archival.window }}}
 
     fromBucket = {{ .Values.influxdb.adminUser.bucket | quote }}
     targetBucket = {{ .Values.archival.bucket | quote }}

--- a/charts/stiebeleltron-stack/templates/influxdb/cm-influxdb-task.yaml
+++ b/charts/stiebeleltron-stack/templates/influxdb/cm-influxdb-task.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.influxdb.enabled .Values.archival.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "stiebeleltron-stack.fullname" . }}-influxdb-task
+  labels:
+    {{- include "stiebeleltron-stack.labels" . | nindent 4 }}
+data:
+  task.flux: |
+    import "strings"
+
+    option task = {name: "Downsampling stiebeleltron", every: {{ .Values.archival.window }}}
+
+    fromBucket = {{ .Values.influxdb.adminUser.bucket | quote }}
+    targetBucket = {{ .Values.archival.bucket | quote }}
+
+    from(bucket: fromBucket)
+      |> range(start: -task.every)
+      |> filter(fn: (r) => r._measurement =~ /^stiebeleltron_.+$/)
+      |> drop(columns: ["url", "host"])
+      |> aggregateWindow(every: task.every, fn: mean, createEmpty: false)
+      |> to(bucket: targetBucket)
+{{ (.Files.Glob "files/influxdb/*.sh").AsConfig | indent 2 }}
+{{- end -}}

--- a/charts/stiebeleltron-stack/templates/influxdb/job-influxdb-task.yaml
+++ b/charts/stiebeleltron-stack/templates/influxdb/job-influxdb-task.yaml
@@ -1,0 +1,46 @@
+{{- if and .Values.influxdb.enabled .Values.archival.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "stiebeleltron-stack.fullname" . }}-influxdb-task
+  labels:
+    {{- include "stiebeleltron-stack.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "stiebeleltron-stack.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      initContainers:
+        - name: wait-for-influx
+          image: "{{ .Values.influxdb.image.repository }}:{{ .Values.influxdb.image.tag }}"
+          command: ["/bin/sh"]
+          args:
+            - -c
+            - until influx bucket list; do sleep 2; done
+          env:
+            {{ include "stiebeleltron-stack.influxdb-env" . | nindent 12 }}
+      containers:
+        - name: post-install-job
+          image: "{{ .Values.influxdb.image.repository }}:{{ .Values.influxdb.image.tag }}"
+          command: ["/bin/sh"]
+          args:
+            - /config/task.sh
+          env:
+            {{ include "stiebeleltron-stack.influxdb-env" . | nindent 12 }}
+            - name: INFLUX_BUCKET_NAME
+              value: {{ .Values.archival.bucket }}
+            - name: INFLUX_BUCKET_RETENTION
+              value: {{ .Values.archival.retention }}
+          volumeMounts:
+            - name: scripts
+              mountPath: /config
+      volumes:
+        - name: scripts
+          configMap:
+            name: {{ template "stiebeleltron-stack.fullname" . }}-influxdb-task
+{{- end -}}

--- a/charts/stiebeleltron-stack/values.yaml
+++ b/charts/stiebeleltron-stack/values.yaml
@@ -1,0 +1,69 @@
+# Default values for stiebeleltron-stack.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+nameOverride: stiebeleltron
+fullnameOverride: ""
+
+influxdb:
+  enabled: true
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+
+  adminUser:
+    organization: stiebeleltron
+    bucket: stiebeleltron_live
+    retention_policy: 14d
+
+  persistence:
+    size: 2Gi
+
+  pdb:
+    create: false
+
+stiebeleltron:
+  enabled: true
+  nameOverride: exporter
+  telegraf:
+    enabled: true
+    # -- Interval of sending metrics to InfluxDB.
+    interval: 5s
+    influxdb:
+      url: http://stiebeleltron-influxdb
+      # -- The token to connect to InfluxDB, needs to be equal to `influxdb.adminUser.token`.
+      token: ""
+      # -- The high-precision bucket name, needs to be equal to `influxdb.adminUser.bucket`.
+      bucket: stiebeleltron_live
+    globalTags:
+      # -- The name of the site or environment.
+      site: home
+
+archival:
+  # -- Whether long-term archival is enabled. Note: Disabling archival after installation (when enabled) does not remove the archival bucket.
+  enabled: true
+  # -- Fixed windows of time in which metrics are averaged.
+  window: 10m
+  # -- Name of the archival bucket to create after installation.
+  bucket: stiebeleltron_archive
+  # -- Retention of the archival bucket. `0s` means forever.
+  retention: 0s
+
+grafana:
+  datasource:
+    enabled: true
+    # -- Override the namespace where the ConfigMap is installed, defaults to release namespace.
+    namespace: ""
+    # -- The labels which the sidecar is filtering for data sources.
+    labels:
+      grafana_datasource: "1"
+  dashboard:
+    enabled: true
+    # -- Override the namespace where the ConfigMap is installed, defaults to release namespace.
+    namespace: ""
+    # -- The labels which the sidecar is filtering for dashboards.
+    labels:
+      grafana_dashboard: "1"


### PR DESCRIPTION
#### What this PR does / why we need it:

* Add stiebeleltron-stack for InfluxDB and https://github.com/ccremer/stiebeleltron-exporter

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make docs lint` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/[chart]`
- [x] PR contains the label that identifies the type of change, which is one of
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
