### PR TITLE
Upgrade exporter to v0.1.2

### DIFF
--- a/charts/stiebeleltron-exporter/Chart.yaml
+++ b/charts/stiebeleltron-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/stiebeleltron-exporter/README.md
+++ b/charts/stiebeleltron-exporter/README.md
@@ -1,6 +1,6 @@
 # stiebeleltron-exporter
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Prometheus Exporter for Stiebel Eltron heat pump ISG
 
@@ -50,7 +50,7 @@ Common/Useful Link references from values.yaml
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `"ghcr.io"` | Container image registry |
 | image.repository | string | `"ccremer/stiebeleltron-exporter"` | Location of the container image |
-| image.tag | string | `"v0.1.0"` | Container image tag |
+| image.tag | string | `"v0.1.2"` | Container image tag |
 | imagePullSecrets | list | `[]` | List of image pull secrets if you use a privately hosted image |
 | ingress.annotations | object | `{}` | Additional annotations for the Ingress object |
 | ingress.enabled | bool | `false` | Useful if your Prometheus is outside of the cluster |

--- a/charts/stiebeleltron-exporter/values.yaml
+++ b/charts/stiebeleltron-exporter/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- Location of the container image
   repository: ccremer/stiebeleltron-exporter
   # -- Container image tag
-  tag: v0.1.0
+  tag: v0.1.2
   pullPolicy: IfNotPresent
 
 # -- List of image pull secrets if you use a privately hosted image


### PR DESCRIPTION
#### What this PR does / why we need it:

* Pin image tag to v0.1.2

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make docs lint` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/[chart]`
- [x] PR contains the label that identifies the type of change, which is one of
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
