### PR TITLE
existingSecret for users and configurable accessMode for Samba

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 | [![chart downloads](https://img.shields.io/github/downloads/ccremer/charts/emby-0.2.3/total)](https://github.com/ccremer/charts/releases/tag/emby-0.2.3) | [emby](charts/emby/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/ccremer/charts/fronius-exporter-0.8.1/total)](https://github.com/ccremer/charts/releases/tag/fronius-exporter-0.8.1) | [fronius-exporter](charts/fronius-exporter/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/ccremer/charts/fronius-stack-0.1.5/total)](https://github.com/ccremer/charts/releases/tag/fronius-stack-0.1.5) | [fronius-stack](charts/fronius-stack/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/ccremer/charts/samba-0.1.1/total)](https://github.com/ccremer/charts/releases/tag/samba-0.1.1) | [samba](charts/samba/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/ccremer/charts/samba-0.2.0/total)](https://github.com/ccremer/charts/releases/tag/samba-0.2.0) | [samba](charts/samba/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/ccremer/charts/stiebeleltron-exporter-0.1.1/total)](https://github.com/ccremer/charts/releases/tag/stiebeleltron-exporter-0.1.1) | [stiebeleltron-exporter](charts/stiebeleltron-exporter/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/ccremer/charts/stiebeleltron-stack-0.1.2/total)](https://github.com/ccremer/charts/releases/tag/stiebeleltron-stack-0.1.2) | [stiebeleltron-stack](charts/stiebeleltron-stack/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/ccremer/charts/znapzend-0.5.4/total)](https://github.com/ccremer/charts/releases/tag/znapzend-0.5.4) | [znapzend](charts/znapzend/README.md) |

--- a/charts/samba/Chart.yaml
+++ b/charts/samba/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/samba/README.md
+++ b/charts/samba/README.md
@@ -35,6 +35,7 @@ Refer to [dperson/samba](https://github.com/dperson/samba) on how to do this.
 | imagePullSecrets | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
+| persistence.accessMode | string | `"ReadWriteMany"` | Access mode for the PV |
 | persistence.annotations | object | `{}` | Additional annotations to add to the PVC |
 | persistence.enabled | bool | `false` | Whether a PVC shall be created |
 | persistence.mountPath | string | `"/data"` |  |

--- a/charts/samba/README.md
+++ b/charts/samba/README.md
@@ -1,6 +1,6 @@
 # samba
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A Helm chart for Samba server
 

--- a/charts/samba/README.md
+++ b/charts/samba/README.md
@@ -51,6 +51,7 @@ Refer to [dperson/samba](https://github.com/dperson/samba) on how to do this.
 | resources.requests.cpu | string | `"30m"` |  |
 | resources.requests.memory | string | `"64Mi"` |  |
 | samba.args | list | `[]` | Container args to pass |
+| samba.existingSecretName | string | `""` | Name of an existing secret with USER env var(s). Refer to `templates/secret.yaml` for the format. |
 | samba.rawEnv | object | `{}` | A dict with KEY: VALUE entries to directly define environment variables. |
 | samba.shares | list | `[]` | A list of Samba shares. Convenience wrapper around SHARE env var(s). See [values.yaml](values.yaml) for an example. |
 | samba.users | list | `[]` | A list of users as a convenience wrapper around USER env var(s). See [values.yaml](values.yaml) for an example. |

--- a/charts/samba/templates/deployment.yaml
+++ b/charts/samba/templates/deployment.yaml
@@ -42,9 +42,9 @@ spec:
             - configMapRef:
                 name: {{ include "samba.fullname" . }}
           {{- end }}
-          {{- if .Values.samba.users }}
+          {{- if or .Values.samba.users .Values.samba.existingSecretName }}
             - secretRef:
-                name: {{ include "samba.fullname" . }}
+                name: {{ .Values.samba.existingSecretName | default (include "samba.fullname" .) }}
           {{- end }}
           ports:
             - name: smb

--- a/charts/samba/templates/pvc.yaml
+++ b/charts/samba/templates/pvc.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 spec:
   accessModes:
-    - ReadWriteMany
+    - {{ .Values.persistence.accessMode }}
   resources:
     requests:
       storage: {{ .Values.persistence.size }}

--- a/charts/samba/templates/secret.yaml
+++ b/charts/samba/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.samba.users }}
+{{- if and .Values.samba.users (not .Values.samba.existingSecretName) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/samba/values.yaml
+++ b/charts/samba/values.yaml
@@ -52,6 +52,8 @@ persistence:
   selector: {}
   # -- Storage Class name of the PV
   storageClass: ""
+  # -- Access mode for the PV
+  accessMode: ReadWriteMany
   # -- Additional annotations to add to the PVC
   annotations: {}
 

--- a/charts/samba/values.yaml
+++ b/charts/samba/values.yaml
@@ -16,6 +16,9 @@ samba:
   #   group: smbusers # group name
   #   gid: 1000 # group id
 
+  # -- Name of an existing secret with USER env var(s). Refer to `templates/secret.yaml` for the format.
+  existingSecretName: ""
+
   # -- A list of Samba shares. Convenience wrapper around SHARE env var(s). See [values.yaml](values.yaml) for an example.
   shares: []
   # - name: share # is how it's called for clients, REQUIRED


### PR DESCRIPTION
#### What this PR does / why we need it:

* Enable usage of existingSecret for Samba users: It is now possible to define users separate from the chart, e.g. in a SealedSecret.

* Make accessMode for volumes configurable in Samba: For example hostPath PVs do not support ReadWriteMany.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. -->
- [x] Chart Version bumped
- [x] `make docs lint` passes
- [x] Variables are documented in the values.yaml as required in [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/[chart]`
- [x] PR contains the label that identifies the type of change, which is one of
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
